### PR TITLE
add cpuserver to the initramfs; leave cpu in there for now

### DIFF
--- a/TESTCPU
+++ b/TESTCPU
@@ -7,6 +7,7 @@ u-root \
 	-initcmd=/bbin/cpu \
 	-files  ~/.ssh/cpu_rsa.pub:key.pub \
 	all \
+	github.com/u-root/cpu/cmds/cpuserver \
 	github.com/u-root/cpu/cmds/cpu
 
 sudo /usr/bin/qemu-system-x86_64 -kernel \


### PR DESCRIPTION
cpuserver is our new smaller-footprint server we needed for atomic pi.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>