### PR TITLE
Fix mode setting problem on ubuntu 20

### DIFF
--- a/cmds/cpu/cpu9p.go
+++ b/cmds/cpu/cpu9p.go
@@ -21,15 +21,14 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/hugelgupf/p9/fsimpl/templatefs"
 	"github.com/hugelgupf/p9/p9"
-        "github.com/hugelgupf/p9/fsimpl/templatefs"
-
 )
 
 // cpu9p is a p9.Attacher.
 type cpu9p struct {
 	p9.DefaultWalkGetAttr
-        templatefs.NoopFile
+	templatefs.NoopFile
 
 	path string
 	file *os.File


### PR DESCRIPTION
When cpu exited, the terminal was still in raw mode.
This fixes it. termios/ttys are confusing.

This includes a minor gofmt patch to cpu9p.go

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>