### PR TITLE
cpu/srv: Fix egregious error that has been the forever

### DIFF
--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -277,7 +277,7 @@ func runClient(host, a string) error {
 	// would be a bad move, since people might be tempted to make it
 	// large.
 	const ms = 1000000 * time.Nanosecond
-	deadline := time.Now().Add(1000 * ms)
+	deadline := time.Now().Add(10 * ms)
 
 	// Arrange port forwarding from remote ssh to our server.
 	// Request the remote side to open port 5640 on all interfaces.

--- a/cmds/cpu/srv.go
+++ b/cmds/cpu/srv.go
@@ -22,7 +22,7 @@ func srv(l net.Listener, root string, n nonce, deadline time.Time) {
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 	var (
-		errs chan error
+		errs = make(chan error)
 		c    net.Conn
 		err  error
 	)
@@ -45,7 +45,6 @@ func srv(l net.Listener, root string, n nonce, deadline time.Time) {
 			return
 		}
 		// Without this cancel, the select seems to stick on the context. Fix me.
-		cancel()
 		errs <- nil
 	}()
 

--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -44,7 +44,7 @@ var (
 	keyFile   = flag.String("key", filepath.Join(os.Getenv("HOME"), ".ssh/cpu_rsa"), "key file")
 	bin       = flag.String("bin", "cpu", "path of cpu binary")
 	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
-	dbg9p     = flag.Bool("dbg9p", false, "show 9p io")
+	dbg9p     = flag.String("dbg9p", "0", "show 9p io")
 	root      = flag.String("root", "/", "9p root")
 	bindover  = flag.String("bindover", "/lib:/lib64:/lib32:/usr:/bin:/etc:/home", ": separated list of directories in /tmp/cpu to bind over /")
 	mountopts = flag.String("mountopts", "", "Extra options to add to the 9p mount")


### PR DESCRIPTION
var errs chan error

is not the same as

var errs = make(chan error)

Coming soon: all this becomes packages with real tests.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>