### PR TITLE
cpud: If CPU_NAMESPACE is empty, do no mounts

### DIFF
--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -48,7 +48,6 @@ var (
 	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
 	dbg9p     = flag.Bool("dbg9p", false, "show 9p io")
 	root      = flag.String("root", "/", "9p root")
-	bindover  = flag.String("bindover", "/lib:/lib64:/lib32:/usr:/bin:/etc:/home", ": separated list of directories in /tmp/cpu to bind over /")
 	mountopts = flag.String("mountopts", "", "Extra options to add to the 9p mount")
 	msize     = flag.Int("msize", 1048576, "msize to use")
 	pid1      bool


### PR DESCRIPTION
There is a need to be able to avoid doing any mounts.

in the cpud, if CPU_NAMESPACE is "", send the CPUNONCE anyway, just
to help sequence the client, but do no mounts of any kind, save the private
tmpfs on /tmp/cpu

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>