### PR TITLE
cpud: don't even connect back to the server if CPU_NAMESPACE=""

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -38,7 +38,7 @@ var (
 	pubKeyFile  = flag.String("pk", "key.pub", "file for public key")
 	port        = flag.String("sp", "23", "cpu default port")
 
-	debug     = flag.Bool("d", false, "enable debug prints")
+	debug     = flag.Bool("d", true, "enable debug prints")
 	runAsInit = flag.Bool("init", false, "run as init (Debug only; normal test is if we are pid 1")
 	v         = func(string, ...interface{}) {}
 	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")


### PR DESCRIPTION
There are some pathological weirdnesses we're seeing, so don't even try.

if CPU_NAMESPACE is "", on the client side, don't set up the forwarding
socket, don't want for a connect, and don't start the 9p server.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>