### PR TITLE
cpud: one more go at fixing orphans

### DIFF
--- a/cmds/cpud/init.go
+++ b/cmds/cpud/init.go
@@ -16,12 +16,17 @@ package main
 
 import (
 	"log"
+	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/u-root/u-root/pkg/libinit"
 )
 
 func cpuSetup() error {
+	// The process reaper runs from here, and needs to run
+	// as PID 1.
+	runtime.LockOSThread()
 	log.Printf(`
 
   ####   #####   #    #   ##
@@ -34,15 +39,45 @@ func cpuSetup() error {
 	libinit.SetEnv()
 	libinit.CreateRootfs()
 	libinit.NetInit()
+	// Wait for orphans, forever.
+	// Since there is no way of knowning when we are
+	// done for good, our work here is never done.
+	// A complication is that for long periods of time, there
+	// may be no orphans.In that case, sleep for one second,
+	// and try again. This background load is hardly enough
+	// to matter. And, in general, it will happen by definition
+	// when there is nothing to wait for, i.e. there is nothing
+	// on the node to be upset about.
+	// Were this ever to be a concern, an option is to kick off
+	// a process that will never exit, such that wait4 will always
+	// block and always return when any child process exits.
+	go func() {
+		var numReaped int
+		for {
+			var (
+				s syscall.WaitStatus
+				r syscall.Rusage
+			)
+			p, err := syscall.Wait4(-1, &s, 0, &r)
+			verbose("orphan reaper: returns with %v", p)
+			if p == -1 {
+				verbose("Nothing to wait for, %d wait for so far", numReaped)
+				time.Sleep(time.Second)
+			}
+			if err != nil {
+				log.Printf("CPUD: a process exited with %v, status %v, rusage %v", p, s, r)
+			}
+			numReaped++
+		}
+	}()
+
+	runtime.UnlockOSThread()
 	return nil
 }
 
 func cpuDone(c chan uint) {
-	// We need to reap all children before exiting.
-	log.Printf("CPUD: Waiting for orphaned startup jobs (there may not be any ...)")
-	procs := libinit.WaitOrphans()
 	log.Printf("CPUD: All startup jobs exited")
 	log.Printf("CPUD: Syncing filesystems")
 	syscall.Sync()
-	c <- procs
+	c <- 1
 }


### PR DESCRIPTION
The process management was wrong. Basically, how it must be done:

cpud, in init, starts a process reaper which can never exit and must
run as PID 1. Use LockOSThread to ensure that, and if wait4 returns
empty-handed, sleep one second and try again.

For cpud as -remote, ONLY wait for the process it started, for reasons
described in the code.

This change fixes a lot of corner cases seen in the wild.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>