### PR TITLE
cpu: correctly handle exit status

### DIFF
--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -368,9 +368,16 @@ func main() {
 		log.Fatal("Getting Termios")
 	}
 	if err := runClient(host, a); err != nil {
-		log.Print(err)
+		e := 1
+		if x,ok := err.(*ossh.ExitError); ok {
+			e = x.ExitStatus()
+		}
+		defer os.Exit(e)
 	}
 	if err := termios.SetTermios(0, t); err != nil {
+		// Never make this a log.Fatal, it might
+		// interfere with the exit handling
+		// for errors from the remote process.
 		log.Print(err)
 	}
 }


### PR DESCRIPTION
Until now, due to incorrect exit status handling in cpud,
exit status was not correctly returned to the client.

Now that cpud is fixed, cpu, on error, gets the exit status from
the ssh.ExitStatus if that is the return type; or it will use
1, and do a deferr'ed os.Exit call in main(). The defer is so that
tty modes can be restored.

This fixes scripts that invoked cpu and did not work right as they
never got an error.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>