### PR TITLE
cpud: turn debug back off

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -37,7 +37,7 @@ var (
 	pubKeyFile  = flag.String("pk", "key.pub", "file for public key")
 	port        = flag.String("sp", "23", "cpu default port")
 
-	debug     = flag.Bool("d", true, "enable debug prints")
+	debug     = flag.Bool("d", false, "enable debug prints")
 	runAsInit = flag.Bool("init", false, "run as init (Debug only; normal test is if we are pid 1")
 	v         = func(string, ...interface{}) {}
 	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")


### PR DESCRIPTION
Debug had been left on to chase down some problems. It can
default to off now.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>