### PR TITLE
cpud: Only allow -init or -remote to be set

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -224,6 +224,9 @@ func runRemote(cmd, port9p string) error {
 // single threaded.
 func init() {
 	flag.Parse()
+	if *runAsInit && *remote {
+		log.Fatal("Only use -remote or -init, not both")
+	}
 	if os.Getpid() == 1 {
 		pid1, *runAsInit, *debug = true, true, false
 	}


### PR DESCRIPTION
Failure of vision on my part, these switches are misnamed,
but it's too late to change them.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>