### PR TITLE
cpud: add -fstab switch

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"flag"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 	// We use this ssh because it implements port redirection.
 	// It can not, however, unpack password-protected keys yet.
 	"github.com/gliderlabs/ssh"
+	"github.com/hashicorp/go-multierror"
 	"github.com/kr/pty" // TODO: get rid of krpty
 	"github.com/u-root/u-root/pkg/termios"
 	"github.com/u-root/u-root/pkg/ulog"
@@ -87,6 +89,54 @@ func buildCmd(cmd string) []string {
 		}
 	}
 	return strings.Fields(cmd)
+}
+
+// fstab makes a best-case effort to mount the mounts passed in a
+// string formatted to the fstab standard.
+// Callers should not die on a returned error,
+// but be left in a situation in which further diagnostics are possible.
+// i.e, follow the "Boots not Bricks" principle.
+func fstab(t string) error {
+	var result error
+
+	var lineno int
+	s := bufio.NewScanner(strings.NewReader(t))
+	for s.Scan() {
+		lineno++
+		l := s.Text()
+		if strings.HasPrefix(l, "#") {
+			continue
+		}
+		f := strings.Fields(l)
+		// fstab is historical, pretty free format.
+		// Users may have dropped a random fstab in and we need
+		// to be forgiving.
+		// The last two fields no longer have any meaning or use.
+		if len(f) < 6 {
+			continue
+		}
+
+		// fstab fields:
+		// /dev/disk/by-uuid/c0d2b09d-5330-4d08-a787-6e0e95592bf3 /boot ext4 defaults 0 0
+		// what to mount, where to mount, fstype, options
+		// Note that flags are old school, binary numbers, and we're hoping to avoid them.
+		// We do need NOT to set MS_PRIVATE, since we've done a successful unshare.
+		// This note is here in case someone gets confused in the future.
+		// If you set this flag to MS_PRIVATE, on some file systems, you'll get an EINVAL.
+		var flags uintptr // = uintptr(unix.MS_PRIVATE)
+		dev, where, fstype, opts := f[0], f[1], f[2], f[3]
+		// The man page implies that the Linux kernel handles flags of "defaults"
+		// we do no further manipulation of opts.
+		v("Line %d: Try to mount %q(%q)", lineno, l, f)
+		if err := os.MkdirAll(where, 0666); err != nil && !os.IsExist(err) {
+			result = multierror.Append(result, err)
+			continue
+		}
+		if err := unix.Mount(dev, where, fstype, flags, opts); err != nil {
+			result = multierror.Append(result, fmt.Errorf("Mount(%q, %q, %q, %#x, %q): %v", dev, where, fstype, flags, opts, err))
+		}
+	}
+	return result
 }
 
 // start up a namespace. We must
@@ -209,6 +259,24 @@ func runRemote(cmd, port9p string) error {
 		}
 	}
 	v("CPUD: bind mounts done")
+
+	// The CPU_FSTAB environment variable is, literally, an fstab.
+	// Why an environment variable and not a file? We do not
+	// want to require any 9p mounts at all. People should be able
+	// to do this:
+	// CPU_NAMESPACE="" CPU_FSTAB=`cat fstab`
+	// and get the mounts they want. The first uses of this will
+	// be building namespaces with drive and virtiofs.
+	if s, ok := os.LookupEnv("CPU_FSTAB"); ok {
+		if err := fstab(s); err != nil {
+			v("CPUD: fstab mount failure: %v", err)
+			// Should we die if the mounts fail? For now, we think not;
+			// the user may be able to debug if they have a non-empty
+			// CPU_NAMESPACE. Just record that it failed.
+			fail = true
+		}
+	}
+
 	if fail && len(*wtf) != 0 {
 		c := exec.Command(*wtf)
 		c.Stdin, c.Stdout, c.Stderr, c.Dir = os.Stdin, os.Stdout, os.Stderr, "/"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/creack/pty v1.1.11 // indirect
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.10.6 // indirect
 	github.com/klauspost/pgzip v1.2.4 // indirect
 	github.com/u-root/uio v0.0.0-20210528114334-82958018845c // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,10 @@ github.com/google/goexpect v0.0.0-20191001010744-5b6988669ffa/go.mod h1:qtE5aAEk
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f h1:5CjVwnuUcp5adK4gmY6i72gpVFVnZDP2h5TmPScB6u4=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hexdigest/gowrap v1.1.7/go.mod h1:Z+nBFUDLa01iaNM+/jzoOA1JJ7sm51rnYFauKFUB5fs=
 github.com/hexdigest/gowrap v1.1.8/go.mod h1:H/JiFmQMp//tedlV8qt2xBdGzmne6bpbaSuiHmygnMw=


### PR DESCRIPTION
CPU_FSTAB is a string in fstab(5) format, which allows arbitrary
fstab usage. For multiple mounts, just embed newlines in the string
or see the example below for how to populate it from a file.

If we have a guest VM, we can now use virtio-fs and the performance
improvement is pretty stunning.

You can do this:
CPU_NAMESPACE="" PWD=/ CPU_FSTAB="myfs /mnt virtiofs rw 0 0" cpu v ls /mnt

or
CPU_NAMESPACE="" PWD=/ CPU_FSTAB=${fstab} cpu v ls /mnt

for more complex mounts, if you can figure out how to populate an
environment variable from a file without having newlines converted to
spaces :-)

Current limits: code does not parse the options string, so you can not say
CPU_NAMESPACE="" PWD=/ CPU_FSTAB="myfs /mnt virtiofs defaults 0 0" cpu v ls /mnt

since useful defaults are file-system-type specific.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>