### PR TITLE
cpud: remove "key" switch

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -42,7 +42,6 @@ var (
 	v         = func(string, ...interface{}) {}
 	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
 	network   = flag.String("network", "tcp", "network to use")
-	keyFile   = flag.String("key", filepath.Join(os.Getenv("HOME"), ".ssh/cpu_rsa"), "key file")
 	bin       = flag.String("bin", "cpu", "path of cpu binary")
 	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
 	dbg9p     = flag.String("dbg9p", "0", "show 9p io")


### PR DESCRIPTION
The original cpu command followed the plan 9 model of containing
both the client and the server. This got a bit big for flash,
hence cpud and cpu are split.

Remove the "key" switch from cpud, it is not used.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>