### PR TITLE
Add a SetPort function for the Cmd

### DIFF
--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -68,14 +68,14 @@ Host apu2
 	for _, test := range []struct {
 		host string
 		port string
-		want uint16
+		want string
 	}{
 		// Can't really test this atm.
 		//{"apu2", "", "2222"},
-		{"apu2", "23", 23},
+		{"apu2", "23", "23"},
 		// This test ensures we never default to port 22
-		{"bogus", "", 23},
-		{"bogus", "2222", 2222},
+		{"bogus", "", "23"},
+		{"bogus", "2222", "2222"},
 	} {
 		got, err := GetPort(test.host, test.port)
 		if err != nil {
@@ -110,7 +110,7 @@ func TestDialNoAuth(t *testing.T) {
 
 // hostkeyport looks up a host, key, port triple.
 // failure is not an option.
-func hostkeyport() (host string, key string, port uint16, err error) {
+func hostkeyport() (host string, key string, port string, err error) {
 	h := "cputest"
 	host = GetHostName(h)
 	if len(host) == 0 {
@@ -141,7 +141,12 @@ func TestDialAuth(t *testing.T) {
 
 	c := Command(h, "ls", "-l")
 	c.PrivateKeyFile = k
-	c.Port = p
+	if err := c.SetPort(""); err != nil {
+		t.Fatalf("c.SetPort(\"\"): %v != nil", err)
+	}
+	if c.Port != p {
+		t.Fatalf("c.Port(%v) != port(%v)", c.Port, p)
+	}
 	if err := c.Dial(); err != nil {
 		t.Fatalf("Dial: got %v, want nil", err)
 	}

--- a/cpu/fns.go
+++ b/cpu/fns.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	// We use this ssh because it implements port redirection.
@@ -190,7 +189,7 @@ func GetHostName(host string) string {
 // The rules here are messy, since config.Get will return "22" if
 // there is no entry in .ssh/config. 22 is not allowed. So in the case
 // of "22", convert to defaultPort.
-func GetPort(host, port string) (uint16, error) {
+func GetPort(host, port string) (string, error) {
 	p := port
 	V("getPort(%q, %q)", host, port)
 	if len(port) == 0 {
@@ -204,8 +203,7 @@ func GetPort(host, port string) (uint16, error) {
 		V("getPort: return default %q", p)
 	}
 	V("returns %q", p)
-	pn, err := strconv.ParseUint(p, 0, 16)
-	return uint16(pn), err
+	return p, nil
 }
 
 // Signal implements ssh.Signal


### PR DESCRIPTION
Change port type to string

We should not determine the rules of a valid port type in
this package; that's up to the net package.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>