### PR TITLE
cpud: add the server package

### DIFF
--- a/server/doc.go
+++ b/server/doc.go
@@ -1,0 +1,51 @@
+// Copyright 2018-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package server is for building cpu servers, a.k.a. cpud.
+//
+// A cpud is an ssh server with a special handler.  On a normal ssh
+// session, the main task is to set up to run a command attached to a
+// stdin, stdout, and stderr.  This special handler allows port
+// forwarding for 9p mounts, and, on Linux, sets up a bind mount for
+// /tmp/cpu/local to /.
+//
+// cpu was original developed on Plan 9 systems. The assumption was
+// that cpu is used in a single administrative domain. It is very
+// important to ensure that the system you connect to is trusted,
+// since when you connect to it, you are serving files to it, from
+// your system, via 9p. Note that you can serve the remote system from
+// a chroot, docker container, or other restricted environment -- even
+// a virtual machine!  But the two use cases we consider safe are a
+// remote system which is an IoT device which you control; or a remote
+// VM or cloud node which you, similarly, control, i.e. is considered
+// to be part of your own administrative domain.
+//
+// Hence, this implementation of cpu assumes a remote system is
+// in our administrative domain, because it is an IoT, cloud, VM,
+// or similar system. We do not recommend using CPU on systems
+// which you do not completely trust. Use ssh and scp/rsync instead.
+// Making cpu usable in untrusted environments is an unsolved problem.
+// Note that this problem applies, to a lesser extent, to ssh; ssh port
+// forwards are also a point of attack from a remote system.
+//
+// The basic flow of setting up a server is similar to most such servers:
+// a call to a New(), preceded or followed by a call to net.Listen to get
+// a socket, and a call to Serve with the listener. For a usage example,
+// see TestDaemonConnect. The handler code is made a bit messy by the
+// need to support PTYs.
+//
+// Each connection to the server results in the invocation of the
+// commands send from the client. The most common command is something
+// like: cpud -remote -bin cpud -port9p <9pportnumber> [command
+// [arguments]].  If there is no command, servers typically run
+// $SHELL; that is up to whatever binary cpud is asked to run for each
+// session. The -bin cpud part of the args is no longer strictly
+// necessary but is left in for older cpud binaries.xs
+//
+// This package also provides a Session type, created by a call to
+// NewSession.  Sessions are very similar to exec.Command, providing
+// access to Stdin, Stdout, Stderr and a Wait function, for example,
+// although the only Session function that servers usually call is
+// Run.
+package server

--- a/server/key.go
+++ b/server/key.go
@@ -1,0 +1,50 @@
+// Copyright 2018-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package server
+
+var (
+	privateKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEA4naTU4uxmqgpL+v6zIzANIpDeTmvaO+6t25HhlnfhlgDO2dZ
+n4bh28HyPyQZC8b1xrEnGPL8+Wcd2hJwyY8oMwBwJmPahPcX7wlll6q5zqhK0tg0
+CnCF8GoNrdBl0OnXduHQD6WxYGS7JIgSFKKwopgL8RCPg2ZY8rwlI+VwY7n6QjKl
+8nSh6YjalkA9LUSNkf79rAXIhiXiWYJZzV+yUCYCVhb2tKWEDhtczflst1Y9NRDB
+BnyVLPDGhi0oiO0eF/tltCOkOAx3iEsRR+HZ4E2E71cq6iUg/3KIEQioLk1TgpmG
+RevIm5MGCtSJivErfklc569dg3MCvgFzMR2oowIDAQABAoIBAHLbfvdVl3uAJHuY
+rPgHvwgmw/f86NlJFSMpfH9In9TMWL9NOKhvSagiotGhZk6R11+xw8mkm+eGhB5x
+UeD4iYPsifT+mfrsM6hZ1LvqrBiDRIfRfft5fIUl1NA+LRWbNFuoRdVZzS+9hykN
+FlZ++SVOBmh6ZL9ZLm3WPOQK30jEOze3zGFAQedZTeUI0R0YIULStLoToC8bjiAI
+ym3tfltN+0rD8nh+A4+Cn2W00l52VqC+3GyymVLebNBYGmriuH4ru0aHARwZbxjo
+WaRCIRa2tOmgcpRZdyJaxcHhr9hydAzcl2ToXTXS78gXDTBqUzQ8eVvjIx1m5pvz
+gNWYzskCgYEA9s/JkmSqFLS8D1DUnhfHthyOA1HvDsz2uR15Wura7IOyZ4cEiq0b
+BunrJA6gpNNCVXMzaeB4WtruRzx69jhmPutgVR9Si2r8uM66A5MU6AIFr9Pbmqo/
+QR8/Vu9LXNEBJL1bTHXNe3n/ws2cwXQIPS3D12N2kHo7G5wLP07r/HUCgYEA6uTb
+6M77ZSrqvpN1DBqB4jIHGtUBuH4+kBhcbu7HzpCZK2ORhd2X38gscNhEo9ofIEmu
+mM9JUgnMtddq3z4574SuhhXrenOIGXb9JN5agEqF8U8LHZwkWv+CLEhGmqdFYsk2
+VlQwzNNS6NPZ1Tuc2QmwzRIzXwL+xVacP1HpTbcCgYAZxUp70az8qn50bvE0bLE6
+r7KYYCbA+d/NJmm0d49SYNHxA2UTAc4vo58czbYyX6iueW/l3z1R50g4AfWo3ey3
+JyaQ3MtmqU4oEdXUZ7goHYXwfQOSG7KtHxEjB6trzpr69hahXi+NdAijk4qJnI77
+rFqlk8oefdTMJjf6bUgwvQKBgHjPipd71WrcHu4z0zCNdZ4MEwFm6sKkE7NzBB9+
+KkAAuPbK+C68oP9U6h6D7RHE/ttRaj5n5pMOPT6NdAcr7wpU2JpYLcvGHgrS2zIa
+NrvjGG7bM6FgDIbNAXubFM04GQTM7miKVqsSSYM8ar40MeCjDk76/HbyiGygti4P
+CAqTAoGAA6rHnhvE9nmrqI4vS3nwSYF5POhP3JjKQMGc5a3H96hf+eJjNihb0NR1
+fxHFQ8imFzZ5OxTZOdAJwmbYO1iMS2oJ2GwAG5eI9w+xyyEu+QrCffHGHdFas1+C
+uJ2GbxWXZEXGMHS79KrHXMnAFPZLYotgH1v+eTJ631lfZVFCOms=
+-----END RSA PRIVATE KEY-----
+`)
+
+	publicKey = []byte(`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDidpNTi7GaqCkv6/rMjMA0ikN5Oa9o77q3bkeGWd+GWAM7Z1mfhuHbwfI/JBkLxvXGsScY8vz5Zx3aEnDJjygzAHAmY9qE9xfvCWWXqrnOqErS2DQKcIXwag2t0GXQ6dd24dAPpbFgZLskiBIUorCimAvxEI+DZljyvCUj5XBjufpCMqXydKHpiNqWQD0tRI2R/v2sBciGJeJZglnNX7JQJgJWFva0pYQOG1zN+Wy3Vj01EMEGfJUs8MaGLSiI7R4X+2W0I6Q4DHeISxFH4dngTYTvVyrqJSD/cogRCKguTVOCmYZF68ibkwYK1ImK8St+SVznr12DcwK+AXMxHaij rminnich@xcpu`)
+	hostKey   = []byte{}
+	// Why %s and not %d?
+	// https://github.com/kevinburke/ssh_config/issues/2
+	// ssh_config does not do any of the % stuff yet.
+	// So we have to rewrite this with the full path. Ouch.
+	sshConfig = []byte(`
+Host server
+	HostName localhost
+	Port 2222
+	User root
+	IdentityFile %s/server
+`)
+)

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,154 @@
+// Copyright 2018-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	// We use this ssh because it implements port redirection.
+	// It can not, however, unpack password-protected keys yet.
+	"github.com/gliderlabs/ssh"
+	"github.com/kr/pty" // TODO: get rid of krpty
+)
+
+const (
+	defaultPort = "23"
+)
+
+var (
+	v = log.Printf // func(string, ...interface{}) {}
+)
+
+func verbose(f string, a ...interface{}) {
+	v("\r\nCPUD:"+f+"\r\n", a...)
+}
+
+func setWinsize(f *os.File, w, h int) {
+	syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(syscall.TIOCSWINSZ), //nolint
+		uintptr(unsafe.Pointer(&struct{ h, w, x, y uint16 }{uint16(h), uint16(w), 0, 0})))
+}
+
+// errval can be used to examine errors that we don't consider errors
+func errval(err error) error {
+	if err == nil {
+		return err
+	}
+	// Our zombie reaper is occasionally sneaking in and grabbing the
+	// child's exit state. Looks like our process code still sux.
+	if strings.Contains(err.Error(), "no child process") {
+		return nil
+	}
+	return err
+}
+
+func handler(s ssh.Session) {
+	a := s.Command()
+	v("handler: cmd is %q", a)
+	cmd := command(a[0], a[1:]...)
+	cmd.Env = append(cmd.Env, s.Environ()...)
+	ptyReq, winCh, isPty := s.Pty()
+	if isPty {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", ptyReq.Term))
+		f, err := pty.Start(cmd)
+		v("command started with pty")
+		if err != nil {
+			v("CPUD:err %v", err)
+			return
+		}
+		go func() {
+			for win := range winCh {
+				setWinsize(f, win.Width, win.Height)
+			}
+		}()
+		go func() {
+			io.Copy(f, s) //nolint stdin
+		}()
+		io.Copy(s, f) //nolint stdout
+		// Stdout is closed, "there's no more to the show/
+		// If you all want to breath right/you all better go"
+		// This is going to seem a bit odd, but it is important to
+		// only wait for the process started here, not any orphans.
+		// In most cases, that process is either a singleton (so the wait
+		// will be all we need); a shell (which does all the waiting for
+		// its children); or the rare case of a detached process (in which
+		// case the reaper will get it).
+		// Seen in the wild: were this code to wait for orphans,
+		// and the main loop to wait for orphans, they end up
+		// competing with each other and the results are odd to say the least.
+		// If the command exits, leaving orphans behind, it is the job
+		// of the reaper to get them.
+		v("wait for %q", cmd)
+		err = cmd.Wait()
+		v("cmd %q returns with %v %v", cmd, err, cmd.ProcessState)
+		if errval(err) != nil {
+			v("CPUD:child exited with  %v", err)
+			s.Exit(cmd.ProcessState.ExitCode()) //nolint
+		}
+
+	} else {
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = s, s, s
+		v("running command without pty")
+		if err := cmd.Run(); errval(err) != nil {
+			v("CPUD:err %v", err)
+			s.Exit(1) //nolint
+		}
+	}
+	verbose("handler exits")
+}
+
+// New sets up a cpud. cpud is really just an SSH server with a special
+// handler and support for port forwarding for the 9p port.
+func New(publicKeyFile, hostKeyFile string) (*ssh.Server, error) {
+	v("configure SSH server")
+	publicKeyOption := func(ctx ssh.Context, key ssh.PublicKey) bool {
+		data, err := ioutil.ReadFile(publicKeyFile)
+		if err != nil {
+			fmt.Print(err)
+			return false
+		}
+		allowed, _, _, _, err := ssh.ParseAuthorizedKey(data)
+		if err != nil {
+			fmt.Print(err)
+			return false
+		}
+		return ssh.KeysEqual(key, allowed)
+	}
+
+	// Now we run as an ssh server, and each time we get a connection,
+	// we run that command after setting things up for it.
+	forwardHandler := &ssh.ForwardedTCPHandler{}
+	server := &ssh.Server{
+		LocalPortForwardingCallback: ssh.LocalPortForwardingCallback(func(ctx ssh.Context, dhost string, dport uint32) bool {
+			log.Println("CPUD:Accepted forward", dhost, dport)
+			return true
+		}),
+		// Pick a reasonable default, which can be used for a call to listen and which
+		// will be overridden later from a listen.Addr
+		Addr:             ":23",
+		PublicKeyHandler: publicKeyOption,
+		ReversePortForwardingCallback: ssh.ReversePortForwardingCallback(func(ctx ssh.Context, host string, port uint32) bool {
+			v("CPUD:attempt to bind", host, port, "granted")
+			return true
+		}),
+		RequestHandlers: map[string]ssh.RequestHandler{
+			"tcpip-forward":        forwardHandler.HandleSSHRequest,
+			"cancel-tcpip-forward": forwardHandler.HandleSSHRequest,
+		},
+		Handler: handler,
+	}
+
+	if err := server.SetOption(ssh.HostKeyFile(hostKeyFile)); err != nil {
+		// We don't much care about this, what's the right thing to do here?
+		// just printint from this function is kind of icky.
+	}
+	return server, nil
+}

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -1,0 +1,80 @@
+// Copyright 2018-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/sys/unix"
+)
+
+// cpud can run in one of three modes
+// o init
+// o daemon started by init
+// o manager of one cpu session.
+// It is *critical* that the session manager have a private
+// name space, else every cpu session will interfere with every
+// other session's mounts. What's the best way to ensure the manager
+// gets a private name space, and ensure that no improper use
+// of this package will result in NOT having a private name space?
+// How do we make the logic failsafe?
+//
+// It turns out there is no harm in always privatizing the name space,
+// no matter the mode.
+// So in this init function, we do not parse flags (that breaks tests;
+// flag.Parse() in init is a no-no), and then, no
+// matter what, privatize the namespace, and mount a private /tmp/cpu if we
+// are not pid1. As for pid1 tasks, they should be specified by the cpud
+// itself, not this package. This code merely ensures correction operation
+// of cpud no matter what mode it is invoked in.
+func init() {
+	// placeholder. It's not clear we ever want to do this. We used to create
+	// a root file system here, but that should be up to the server. The files
+	// might magically exist, b/c of initrd; or be automagically mounted via
+	// some other mechanism.
+	if os.Getpid() == 1 {
+		v("PID 1")
+	}
+}
+
+func osMounts() error {
+	var errors error
+	// Further, bind / onto /tmp/local so a non-hacked-on version may be visible.
+	if err := unix.Mount("/", "/tmp/local", "", syscall.MS_BIND, ""); err != nil {
+		errors = multierror.Append(fmt.Errorf("CPUD:Warning: binding / over /tmp/local did not work: %v, continuing anyway", err))
+	}
+	return errors
+}
+
+// func logopts() {
+// 	if *klog {
+// 		ulog.KernelLog.Reinit()
+// 		v = ulog.KernelLog.Printf
+// 	}
+// }
+
+func command(n string, args ...string) *exec.Cmd {
+	cmd := exec.Command(n, args...)
+	// N.B.: in the go runtime, after not long ago, CLONE_NEWNS in the Unshareflags
+	// also does two things: an unshare, and a remount of / to unshare mounts.
+	// see d8ed449d8eae5b39ffe227ef7f56785e978dd5e2 in the go tree for a discussion.
+	// This meant we could remove ALL calls of unshare and mount from cpud.
+	// Fun fact: I wrote that fix years ago, and then forgot to remove
+	// the support code from cpu. Oops.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Unshareflags: syscall.CLONE_NEWNS}
+	return cmd
+}
+
+// runSetup performs kernel-specific operations for starting a Session.
+func runSetup() error {
+	if err := unix.Mount("cpu", "/tmp", "tmpfs", 0, ""); err != nil {
+		return fmt.Errorf(`unix.Mount("cpu", "/tmp", "tmpfs", 0, ""); %v != nil`, err)
+	}
+	return nil
+}

--- a/server/server_linux_test.go
+++ b/server/server_linux_test.go
@@ -1,0 +1,245 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+
+	config "github.com/kevinburke/ssh_config"
+	"github.com/u-root/cpu/client"
+	"golang.org/x/sys/unix"
+)
+
+func TestHelperProcess(t *testing.T) {
+	v, ok := os.LookupEnv("GO_WANT_HELPER_PROCESS")
+	if !ok {
+		t.Logf("just a helper")
+		return
+	}
+	t.Logf("Check %q", v)
+	if err := unix.Mount("cpu", v, "tmpfs", 0, ""); err != nil {
+		t.Fatalf("unix.Mount(cpu, %q, \"tmpfs\"): %v != nil", v, err)
+	}
+
+	vanish := filepath.Join(v, "vanish")
+	t.Logf("Mount ok, try to create %q", vanish)
+	msg := "This should not be visible in the parent"
+	if err := ioutil.WriteFile(vanish, []byte(msg), 0644); err != nil {
+		t.Fatalf(`ioutil.WriteFile(%q, %q, 0644): %v != nil`, vanish, msg, err)
+	}
+	t.Logf("Created %q", vanish)
+}
+
+// TestPrivateNameSpace tests if we are privatizing mounts
+// correctly. We spawn a child with syscall.CLONE_NEWNS set.
+// The child mounts a tmpfs over the directory, and creates a
+// file. When it exits, and returns to us, that file should
+// not be visible.
+func TestPrivateNameSpace(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skipf("Skipping; not root")
+	}
+	d := t.TempDir()
+	t.Logf("Call helper %q", os.Args[0])
+	c := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "-test.v")
+	c.Env = []string{"GO_WANT_HELPER_PROCESS=" + d}
+	c.SysProcAttr = &syscall.SysProcAttr{Unshareflags: syscall.CLONE_NEWNS}
+	o, err := c.CombinedOutput()
+	t.Logf("out %s", o)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	vanish := filepath.Join(d, "vanish")
+	if _, err := os.Stat(vanish); err == nil {
+		t.Logf("Privatization failed ... Try to unmount %v", d)
+		if err := unix.Unmount(d, unix.MNT_FORCE); err != nil {
+			t.Fatalf("unix.Unmount( %q, %#x): %v != nil", d, unix.MNT_FORCE, err)
+		}
+		t.Fatalf("os.Stat(%q): nil != err", vanish)
+	}
+}
+
+// Now the fun begins. We have to be a demon.
+func TestDaemonSession(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skipf("Skipping as we are not root")
+	}
+
+	runtime.GOMAXPROCS(1)
+	v = t.Logf
+	d := t.TempDir()
+	t.Logf("tempdir is %q", d)
+	if err := os.Setenv("HOME", d); err != nil {
+		t.Fatalf(`os.Setenv("HOME", %s): %v != nil`, d, err)
+	}
+	dotSSH := filepath.Join(d, ".ssh")
+	hackconfig, err := gendotssh(d, string(sshConfig))
+	if err != nil {
+		t.Fatalf(`gendotssh(%s): %v != nil`, d, err)
+	}
+
+	pubKey := filepath.Join(dotSSH, "server.pub")
+	s, err := New(pubKey, "")
+	if err != nil {
+		t.Fatalf("New(%q, %q): %v != nil", pubKey, "", err)
+	}
+
+	ln, err := net.Listen("tcp", "")
+	if err != nil {
+		t.Fatalf("s.Listen(): %v != nil", err)
+	}
+	t.Logf("Listening on %v", ln.Addr())
+	// this is a racy test.
+	// The ssh package really ought to allow you to accept
+	// on a socket and then call with that socket. This would be
+	// more in line with bsd sockets which let you write a server
+	// and client in line, e.g.
+	// socket/bind/listen/connect/accept
+	// oh well.
+	go func(t *testing.T) {
+		if err := s.Serve(ln); err != nil {
+			t.Errorf("s.Daemon(): %v != nil", err)
+		}
+	}(t)
+	v = t.Logf
+	// From this test forward, at least try to get a port.
+	// For this test, there must be a key.
+	// hack for lack in ssh_config
+	// https://github.com/kevinburke/ssh_config/issues/2
+	cfg, err := config.Decode(bytes.NewBuffer([]byte(hackconfig)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, err := cfg.Get("server", "HostName")
+	if err != nil || len(host) == 0 {
+		t.Fatalf(`cfg.Get("server", "HostName"): (%q, %v) != (localhost, nil`, host, err)
+	}
+	kf, err := cfg.Get("server", "IdentityFile")
+	if err != nil || len(kf) == 0 {
+		t.Fatalf(`cfg.Get("server", "IdentityFile"): (%q, %v) != (afilename, nil`, kf, err)
+	}
+	host, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("net.SplitHostPort(%q): %v != nil", ln.Addr(), err)
+	}
+
+	t.Logf("HostName %q, IdentityFile %q, command %v", host, kf, os.Args[0])
+	client.V = t.Logf
+	c := client.Command(host, os.Args[0], "-remote", "-bin", os.Args[0], "ls", "-l").WithPrivateKeyFile(kf).WithPort(port).WithRoot(d).WithNameSpace(d)
+	if err := c.Dial(); err != nil {
+		t.Fatalf("Dial: got %v, want nil", err)
+	}
+	if err = c.Start(); err != nil {
+		t.Fatalf("Start: got %v, want nil", err)
+	}
+	defer func() {
+		if err := c.Close(); err != nil {
+			t.Fatalf("Close: got %v, want nil", err)
+		}
+	}()
+	if err := c.Stdin.Close(); err != nil && !errors.Is(err, io.EOF) {
+		t.Errorf("Close stdin: Got %v, want nil", err)
+	}
+	if err := c.Wait(); err != nil {
+		t.Fatalf("Wait: got %v, want nil", err)
+	}
+	r, err := c.Outputs()
+	if err != nil {
+		t.Errorf("Outputs: got %v, want nil", err)
+	}
+	t.Logf("c.Run: (%v, %q, %q)", err, r[0].String(), r[1].String())
+}
+
+// TestDaemonConnect tests connecting to a daemon and exercising
+// minimal operations.
+func TestDaemonConnect(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skipf("Skipping as we are not root")
+	}
+	d := t.TempDir()
+	if err := os.Setenv("HOME", d); err != nil {
+		t.Fatalf(`os.Setenv("HOME", %s): %v != nil`, d, err)
+	}
+	hackconfig, err := gendotssh(d, string(sshConfig))
+	if err != nil {
+		t.Fatalf(`gendotssh(%s): %v != nil`, d, err)
+	}
+
+	v = t.Logf
+	s, err := New(filepath.Join(d, ".ssh", "server.pub"), filepath.Join(d, ".ssh", "hostkey"))
+	if err != nil {
+		t.Fatalf(`New(%q, %q): %v != nil`, filepath.Join(d, ".ssh", "server.pub"), filepath.Join(d, ".ssh", "hostkey"), err)
+	}
+
+	ln, err := net.Listen("tcp", "")
+	if err != nil {
+		t.Fatalf(`net.Listen("", ""): %v != nil`, err)
+	}
+	t.Logf("Listening on %v", ln.Addr())
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// this is a racy test.
+	// The ssh package really ought to allow you to accept
+	// on a socket and then call with that socket. This would be
+	// more in line with bsd sockets which let you write a server
+	// and client in line, e.g.
+	// socket/bind/listen/connect/accept
+	// oh well.
+	go func(t *testing.T) {
+		if err := s.Serve(ln); err != nil {
+			t.Errorf("s.Daemon(): %v != nil", err)
+		}
+	}(t)
+	v = t.Logf
+	// From this test forward, at least try to get a port.
+	// For this test, there must be a key.
+	// hack for lack in ssh_config
+	// https://github.com/kevinburke/ssh_config/issues/2
+	cfg, err := config.Decode(bytes.NewBuffer([]byte(hackconfig)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, err := cfg.Get("server", "HostName")
+	if err != nil || len(host) == 0 {
+		t.Fatalf(`cfg.Get("server", "HostName"): (%q, %v) != (localhost, nil`, host, err)
+	}
+	kf, err := cfg.Get("server", "IdentityFile")
+	if err != nil || len(kf) == 0 {
+		t.Fatalf(`cfg.Get("server", "IdentityFile"): (%q, %v) != (afilename, nil`, kf, err)
+	}
+	t.Logf("HostName %q, IdentityFile %q", host, kf)
+	c := client.Command(host, os.Args[0]+" -test.run TestDaemonConnectHelper -test.v --", "date").WithPrivateKeyFile(kf).WithPort(port).WithRoot("/").WithNameSpace("")
+	c.Env = append(c.Env, "GO_WANT_DAEMON_HELPER_PROCESS=1")
+	if err := c.Dial(); err != nil {
+		t.Fatalf("Dial: got %v, want nil", err)
+	}
+	if err = c.Start(); err != nil {
+		t.Fatalf("Start: got %v, want nil", err)
+	}
+	defer func() {
+		if err := c.Close(); err != nil {
+			t.Fatalf("Close: got %v, want nil", err)
+		}
+	}()
+	if err := c.Stdin.Close(); err != nil && !errors.Is(err, io.EOF) {
+		t.Errorf("Close stdin: Got %v, want nil", err)
+	}
+	if err := c.Wait(); err != nil {
+		t.Fatalf("Wait: got %v, want nil", err)
+	}
+	r, err := c.Outputs()
+	if err != nil {
+		t.Errorf("Outputs: got %v, want nil", err)
+	}
+	t.Logf("c.Run: (%v, %q, %q)", err, r[0].String(), r[1].String())
+}

--- a/server/server_other.go
+++ b/server/server_other.go
@@ -1,0 +1,63 @@
+// Copyright 2018-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !linux
+// +build !linux
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+)
+
+// Namespace assembles a NameSpace for this cpud, iff CPU_NAMESPACE
+// is set.
+// CPU_NAMESPACE can be the empty string.
+// It also requires that CPU_NONCE exist.
+func (s *Session) Namespace() (error, error) {
+	var warning error
+	// Get the nonce and remove it from the environment.
+	// N.B. We do not save the nonce in the cpu struct.
+	nonce := os.Getenv("CPUNONCE")
+	os.Unsetenv("CPUNONCE")
+	v("CPUD:namespace is %q", s.binds)
+
+	// Connect to the socket, return the nonce.
+	a := net.JoinHostPort("127.0.0.1", s.port9p)
+	v("CPUD:Dial %v", a)
+	so, err := net.Dial("tcp", a)
+	if err != nil {
+		return warning, fmt.Errorf("CPUD:Dial 9p port: %v", err)
+	}
+	v("CPUD:Connected: write nonce %s\n", nonce)
+	if _, err := fmt.Fprintf(so, "%s", nonce); err != nil {
+		return warning, fmt.Errorf("CPUD:Write nonce: %v", err)
+	}
+	v("CPUD:Wrote the nonce")
+	// Zero it. I realize I am not a crypto person.
+	// improvements welcome.
+	copy([]byte(nonce), make([]byte, len(nonce)))
+
+	return warning, fmt.Errorf("CPUD: cannot use 9p connection yet")
+}
+
+func osMounts() error {
+	return nil
+}
+
+func logopts() {
+}
+
+func command(n string, args ...string) *exec.Cmd {
+	cmd := exec.Command(n, args...)
+	return cmd
+}
+
+// runSetup performs kernel-specific operations for starting a Session.
+func runSetup() error {
+	return nil
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,140 @@
+// Copyright 2018-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package server
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/u-root/cpu/session"
+)
+
+func TestNewServer(t *testing.T) {
+	s, err := New("", "")
+	if err != nil {
+		t.Fatalf(`New("", ""): %v != nil`, err)
+	}
+	t.Logf("New server: %v", s)
+}
+
+func TestRemoteNoNameSpace(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skipf("Skipping as we are not root")
+	}
+	v = t.Logf
+	s := session.New("", "date")
+	o, e := &bytes.Buffer{}, &bytes.Buffer{}
+	s.Stdin, s.Stdout, s.Stderr = nil, o, e
+	if err := s.Run(); err != nil {
+		t.Fatalf(`s.Run("", "date"): %v != nil`, err)
+	}
+	t.Logf("%q %q", o, e)
+	if len(o.String()) == 0 {
+		t.Errorf("no command output: \"\" != non-zero-length string")
+	}
+	if e.String() != "" {
+		t.Errorf("command error: %q != %q", e.String(), "")
+	}
+}
+
+func gendotssh(dir, config string) (string, error) {
+	dotssh := filepath.Join(dir, ".ssh")
+	if err := os.MkdirAll(dotssh, 0700); err != nil {
+		return "", err
+	}
+
+	// https://github.com/kevinburke/ssh_config/issues/2
+	hackconfig := fmt.Sprintf(string(sshConfig), filepath.Join(dir, ".ssh"))
+	for _, f := range []struct {
+		name string
+		val  []byte
+	}{
+		{name: "config", val: []byte(hackconfig)},
+		{name: "hostkey", val: hostKey},
+		{name: "server", val: privateKey},
+		{name: "server.pub", val: publicKey},
+	} {
+		if err := ioutil.WriteFile(filepath.Join(dotssh, f.name), f.val, 0644); err != nil {
+			return "", err
+		}
+	}
+	return hackconfig, nil
+}
+
+func TestDaemonStart(t *testing.T) {
+	v = t.Logf
+	s, err := New("", "")
+	if err != nil {
+		t.Fatalf(`New("", ""): %v != nil`, err)
+	}
+
+	ln, err := net.Listen("tcp", "")
+	if err != nil {
+		t.Fatalf("net.Listen(): %v != nil", err)
+	}
+	t.Logf("Listening on %v", ln.Addr())
+	// this is a racy test.
+	go func() {
+		time.Sleep(5 * time.Second)
+		s.Close()
+	}()
+
+	if err := s.Serve(ln); err != ssh.ErrServerClosed {
+		t.Fatalf("s.Daemon(): %v != %v", err, ssh.ErrServerClosed)
+	}
+	t.Logf("Daemon returns")
+}
+
+func TestDaemonConnectHelper(t *testing.T) {
+	if _, ok := os.LookupEnv("GO_WANT_DAEMON_HELPER_PROCESS"); !ok {
+		t.Logf("just a helper")
+		return
+	}
+	t.Logf("As a helper, we are supposed to run %q", args)
+	s := session.New(port9p, args[0], args[1:]...)
+	// Step through the things a server is supposed to do with a session
+	if err := s.Run(); err != nil {
+		log.Fatalf("CPUD(as remote):%v", err)
+	}
+}
+
+var (
+	args   []string
+	port9p string
+)
+
+func TestMain(m *testing.M) {
+	// Strip out the args after --
+	x := -1
+	var osargs = os.Args
+	for i := range os.Args {
+		if x > 0 {
+			args = os.Args[i:]
+			break
+		}
+		if os.Args[i] == "--" {
+			osargs = os.Args[:i]
+			x = i
+		}
+	}
+	// Process any port9p directive
+	if len(args) > 1 && args[0] == "-port9p" {
+		port9p = args[1]
+		args = args[2:]
+	}
+	os.Args = osargs
+	// log.Printf("os.Args %v, args %v", os.Args, args)
+	flag.Parse()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
cpud is an sshd which allows a port forward, and sets up a bind
mount for /tmp/cpu/local to /.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>