### PR TITLE
mount: fix parsing

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -65,9 +65,9 @@ func mount(m mounter, fstab string) error {
 			err = multierror.Append(err, e)
 			continue
 		}
-		opt, flags := parse(opts)
-		if e := m(dev, where, fstype, flags, opt); e != nil {
-			err = multierror.Append(err, fmt.Errorf("Mount(%q, %q, %q, %q=>(%#x, %q)): %v", dev, where, fstype, opts, flags, opt, e))
+		flags, data := parse(opts)
+		if e := m(dev, where, fstype, flags, data); e != nil {
+			err = multierror.Append(err, fmt.Errorf("Mount(%q, %q, %q, %q=>(%#x, %q)): %v", dev, where, fstype, opts, flags, data, e))
 		}
 	}
 	return err
@@ -123,9 +123,9 @@ var ignore = map[string]interface{}{
 	"nouser": nil,
 }
 
-func parse(m string) (string, uintptr) {
-	var ret []string
-	var opt uintptr
+func parse(m string) (uintptr, string) {
+	var opts []string
+	var flags uintptr
 	for _, f := range strings.Split(strings.TrimSpace(m), ",") {
 		if f == "defaults" {
 			// "rw", "suid", "dev", "exec", "auto", "nouser", "async"
@@ -140,11 +140,11 @@ func parse(m string) (string, uintptr) {
 			continue
 		}
 		if v, ok := convert[f]; ok {
-			opt |= v
+			flags |= v
 		} else if _, ok := ignore[f]; !ok {
-			ret = append(ret, f)
+			opts = append(opts, f)
 		}
 	}
-	return strings.Join(ret, ","), opt
+	return flags, strings.Join(opts, ",")
 
 }

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -60,8 +60,6 @@ func TestParse(t *testing.T) {
 		{in: "rw", flag: 0, opt: ""},
 		{in: "rw,nosuid,nodev", flag: unix.MS_NOSUID | unix.MS_NODEV, opt: ""},
 		{in: "rw,nosuid,nodev,noexec,relatime", flag: unix.MS_RELATIME | unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC, opt: ""},
-		{in: "rw,nosuid,nodev,noexec,relatime", flag: unix.MS_RELATIME | unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC, opt: ""},
-
 		{in: "rw,nosuid,nodev,noexec,relatime,cpu,cpuacct", flag: unix.MS_RELATIME | unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC, opt: "cpu,cpuacct"},
 		{in: "rw,nosuid,nodev,noexec,relatime,cpuset", flag: unix.MS_RELATIME | unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC, opt: "cpuset"},
 		{in: "rw,nosuid,nodev,noexec,relatime", flag: unix.MS_RELATIME | unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC, opt: ""},
@@ -89,10 +87,9 @@ func TestParse(t *testing.T) {
 		{in: "rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro", flag: 0x200000, opt: "fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro"},
 		{in: "rw,relatime,pagesize=2M", flag: 0x200000, opt: "pagesize=2M"},
 	} {
-		opt, flag := parse(tt.in)
+		flag, opt := parse(tt.in)
 		if opt != tt.opt {
 			t.Errorf("Parsing %s(%d): got (%#x, %s), want (%#x, %s)", tt.in, i, flag, opt, tt.flag, tt.opt)
-			t.Errorf("{in: %q, flag: %#x, opt: %q,},", tt.in, flag, opt)
 		}
 
 	}


### PR DESCRIPTION
I misread how much the kernel is willing to do for mounting.
This should work far better.

It converts options that need to be bits to the flag,
and leaves other options in the data string.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>