### PR TITLE
Cleanup per golangci-lint

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -119,7 +119,7 @@ func Command(host string, args ...string) *Cmd {
 		// Also, there is the nagging concern that we're not
 		// totally proper yet on the security issues
 		// around letting users run arbitrary binaries.
-		cmd: "cpud -remote -bin cpud",
+		cmd: "cpud -remote",
 	}
 }
 
@@ -183,10 +183,6 @@ func (c *Cmd) WithRoot(root string) *Cmd {
 // WithCpudCommand sets the initial command to run on the
 // remote side. This is extremely helpful when testing new
 // implementations of cpud, of little use otherwise.
-// But, for example, when testing the new package-based
-// cpud, we can run:
-// cpu -cmd 'cpud -new=true -remote -bin cpud'
-// and cpu will use WithCpudCommand to set the command.
 func (c *Cmd) WithCpudCommand(cmd string) *Cmd {
 	c.cmd = cmd
 	return c

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -42,7 +42,7 @@ var (
 	defaultKeyFile = filepath.Join(os.Getenv("HOME"), ".ssh/cpu_rsa")
 	// For the ssh server part
 	bin         = flag.String("bin", "cpud", "path of cpu binary")
-	cpudCmd     = flag.String("cpudcmd", "", "cpud invocation to run at remote, e.g. cpud -d -bin cpud")
+	cpudCmd     = flag.String("cpudcmd", "", "cpud invocation to run at remote, e.g. cpud -d")
 	debug       = flag.Bool("d", false, "enable debug prints")
 	dbg9p       = flag.Bool("dbg9p", false, "show 9p io")
 	dump        = flag.Bool("dump", false, "Dump copious output, including a 9p trace, to a temp file at exit")
@@ -146,7 +146,7 @@ func runClient(host, a, port, key string) error {
 	}
 
 	var env []string
-	cmd := fmt.Sprintf("%v -remote -bin %v", *bin, *bin)
+	cmd := fmt.Sprintf("%v -remote", *bin)
 
 	_, wantNameSpace := os.LookupEnv("CPU_NAMESPACE")
 	wantNameSpace = wantNameSpace || *namespace != "none"

--- a/cmds/cpu/doc.go
+++ b/cmds/cpu/doc.go
@@ -70,8 +70,6 @@
 //           Note that the 9p server is also enabled if the namespace
 //           is not empty. To ensure the 9p server is not set,
 //           cpu -9p=f -namespace=""
-//     -bin string
-//           path of cpu binary
 //     -d
 //           enable debug prints
 //     -dbg9p

--- a/cmds/cpud/cpuddoc.go
+++ b/cmds/cpud/cpuddoc.go
@@ -10,8 +10,6 @@
 // Advisory:
 //
 // Options:
-//     -bin string
-//           path of cpu binary
 //     -d    enable debug prints
 //     -dbg9p
 //           show 9p io

--- a/cmds/cpud/init.go
+++ b/cmds/cpud/init.go
@@ -79,10 +79,3 @@ func cpuSetup() error {
 	runtime.UnlockOSThread()
 	return nil
 }
-
-func cpuDone(c chan uint) {
-	log.Printf("CPUD: All startup jobs exited")
-	log.Printf("CPUD: Syncing filesystems")
-	syscall.Sync()
-	c <- 1
-}

--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -5,11 +5,9 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"log"
 	"os"
-	"strings"
 
 	// We use this ssh because it implements port redirection.
 	// It can not, however, unpack password-protected keys yet.
@@ -29,49 +27,14 @@ var (
 	v         = func(string, ...interface{}) {}
 	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
 	network   = flag.String("network", "tcp", "network to use")
-	bin       = flag.String("bin", "cpu", "path of cpu binary")
 	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
-	dbg9p     = flag.String("dbg9p", "0", "show 9p io")
-	root      = flag.String("root", "/", "9p root")
 	klog      = flag.Bool("klog", false, "Log cpud messages in kernel log, not stdout")
 
-	mountopts = flag.String("mountopts", "", "Extra options to add to the 9p mount")
-	msize     = flag.Int("msize", 1048576, "msize to use")
-	// To get debugging when Things Go Wrong, you can run as, e.g., -wtf /bbin/elvish
-	// or change the value here to /bbin/elvish.
-	// This way, when Things Go Wrong, you'll be dropped into a shell and look around.
-	// This is sometimes your only way to debug if there is (e.g.) a Go runtime
-	// bug around unsharing. Which has happened.
-	wtf  = flag.String("wtf", "", "Command to run if setup (e.g. private name space mounts) fail")
 	pid1 bool
-	// This flag indicates we are running the package version of the server.
-	packageServer = flag.Bool("new", true, "use Package version of cpud")
 )
 
 func verbose(f string, a ...interface{}) {
 	v("\r\nCPUD:"+f+"\r\n", a...)
-}
-
-// errval can be used to examine errors that we don't consider errors
-func errval(err error) error {
-	if err == nil {
-		return err
-	}
-	// Our zombie reaper is occasionally sneaking in and grabbing the
-	// child's exit state. Looks like our process code still sux.
-	if strings.Contains(err.Error(), "no child process") {
-		return nil
-	}
-	return err
-}
-
-// TODO: we've been trying to figure out the right way to do usage for years.
-// If this is a good way, it belongs in the uroot package.
-func usage() {
-	var b bytes.Buffer
-	flag.CommandLine.SetOutput(&b)
-	flag.PrintDefaults()
-	log.Fatalf("Usage: cpu [options] host [shell command]:\n%v", b.String())
 }
 
 func main() {
@@ -91,7 +54,6 @@ func main() {
 		if err := s.Run(); err != nil {
 			log.Fatalf("CPUD(as remote):%v", err)
 		}
-		break
 	default:
 		log.Fatal("CPUD:can only run as remote or pid 1")
 	}

--- a/server/doc.go
+++ b/server/doc.go
@@ -37,11 +37,10 @@
 //
 // Each connection to the server results in the invocation of the
 // commands send from the client. The most common command is something
-// like: cpud -remote -bin cpud -port9p <9pportnumber> [command
+// like: cpud -remote -port9p <9pportnumber> [command
 // [arguments]].  If there is no command, servers typically run
 // $SHELL; that is up to whatever binary cpud is asked to run for each
-// session. The -bin cpud part of the args is no longer strictly
-// necessary but is left in for older cpud binaries.xs
+// session.
 //
 // This package also provides a Session type, created by a call to
 // NewSession.  Sessions are very similar to exec.Command, providing

--- a/server/server_linux_test.go
+++ b/server/server_linux_test.go
@@ -133,7 +133,7 @@ func TestDaemonSession(t *testing.T) {
 
 	t.Logf("HostName %q, IdentityFile %q, command %v", host, kf, os.Args[0])
 	client.V = t.Logf
-	c := client.Command(host, os.Args[0], "-remote", "-bin", os.Args[0], "ls", "-l").WithPrivateKeyFile(kf).WithPort(port).WithRoot(d).WithNameSpace(d)
+	c := client.Command(host, os.Args[0], "-remote", "ls", "-l").WithPrivateKeyFile(kf).WithPort(port).WithRoot(d).WithNameSpace(d)
 	if err := c.Dial(); err != nil {
 		t.Fatalf("Dial: got %v, want nil", err)
 	}


### PR DESCRIPTION
remove unused variables and functions

remove the -bin switch, which is obviated by the -cpudcmd
switch.

This is a breaking change: older clients will not work
with newer cpud.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>