### PR TITLE
server: turn off debug prints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	v = log.Printf // func(string, ...interface{}) {}
+	v = func(string, ...interface{}) {}
 )
 
 func verbose(f string, a ...interface{}) {


### PR DESCRIPTION
This adds a bit of time overhead which can delay the 9P mount.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>