### PR TITLE
Remove the client 9p timeout

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,7 @@ func New(publicKeyFile, hostKeyFile string) (*ssh.Server, error) {
 		Addr:             ":" + defaultPort,
 		PublicKeyHandler: publicKeyOption,
 		ReversePortForwardingCallback: ssh.ReversePortForwardingCallback(func(ctx ssh.Context, host string, port uint32) bool {
-			v("CPUD:attempt to bind", host, port, "granted")
+			v("CPUD:ReversePortForwardingCallback: attempt to bind %v %v granted", host, port)
 			return true
 		}),
 		RequestHandlers: map[string]ssh.RequestHandler{


### PR DESCRIPTION
The 9p timeout was originally a way to ensure that the cpud connecting
was the cpud we wanted to connect. It was a very poor security
mechanism.

The use of private fdno mounts and CPUNONCE eliminate the need for a timeout.

In most cases, nowadays, the timeout was causing problems, rather than
showing problems, as it is basically a race condition: the client
has to set up the socket, and wait for a connect; meanwhile, client
must also start up the cpud as fast as it can, before the timeout fires!

It was useful in its time, but the timeout is more of a headache than
anything. Further, it can result in a case where we are running a
remote session, even though the mounts failed, which is a worst
case scenario.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>