### PR TITLE
Make With* idiomatic Go

### DIFF
--- a/client/cpu_test.go
+++ b/client/cpu_test.go
@@ -137,10 +137,10 @@ func TestDialAuth(t *testing.T) {
 	// From this test forward, at least try to get a port.
 	// For this test, there must be a key.
 
-	c := Command(h, "ls", "-l").WithNameSpace(DefaultNameSpace)
+	c := Command(h, "ls", "-l")
 	c.PrivateKeyFile = k
-	if err := c.SetPort(""); err != nil {
-		t.Fatalf("c.SetPort(\"\"): %v != nil", err)
+	if c.SetOptions(WithNameSpace(DefaultNameSpace), WithPort("")); err != nil {
+		t.Fatalf("Options(): %v != nil", err)
 	}
 	if c.Port != p {
 		t.Fatalf("c.Port(%v) != port(%v)", c.Port, p)
@@ -166,7 +166,10 @@ func TestDialRun(t *testing.T) {
 	// From this test forward, at least try to get a port.
 	// For this test, there must be a key.
 
-	c := Command(h, "ls", "-l").WithPrivateKeyFile(k).WithPort(p).WithRoot("/").WithNameSpace(DefaultNameSpace)
+	c := Command(h, "ls", "-l")
+	if err := c.SetOptions(WithPrivateKeyFile(k), WithPort(p), WithRoot("/"), WithNameSpace(DefaultNameSpace)); err != nil {
+		t.Fatalf("SetOptions: %v != nil", err)
+	}
 	if err := c.Dial(); err != nil {
 		t.Fatalf("Dial: got %v, want nil", err)
 	}
@@ -205,7 +208,10 @@ func TestSetupInteractive(t *testing.T) {
 	// From this test forward, at least try to get a port.
 	// For this test, there must be a key.
 
-	c := Command(h, "ls", "-l").WithPrivateKeyFile(k).WithPort(p).WithRoot("/").WithNameSpace(DefaultNameSpace)
+	c := Command(h, "ls", "-l")
+	if err := c.SetOptions(WithPrivateKeyFile(k), WithPort(p), WithRoot("/"), WithNameSpace(DefaultNameSpace)); err != nil {
+		t.Fatalf("SetOptions: %v != nil ", err)
+	}
 	if err := c.Dial(); err != nil {
 		t.Fatalf("Dial: got %v, want nil", err)
 	}

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -137,24 +137,18 @@ func usage() {
 func newCPU(host string, args ...string) error {
 	client.V = v
 	// note that 9P is enabled if namespace is not empty OR if ninep is true
-	c := client.Command(host, args...).
-		WithPrivateKeyFile(*keyFile).
-		WithHostKeyFile(*hostKeyFile).
-		WithPort(*port).
-		WithRoot(*root).
-		WithNameSpace(*namespace).
-		With9P(*ninep)
-
-	if err := c.SetTimeout(*timeout9P); err != nil {
+	c := client.Command(host, args...)
+	if err := c.SetOptions(
+		client.WithPrivateKeyFile(*keyFile),
+		client.WithHostKeyFile(*hostKeyFile),
+		client.WithPort(*port),
+		client.WithRoot(*root),
+		client.WithNameSpace(*namespace),
+		client.With9P(*ninep),
+		client.WithFSTab(*fstab),
+		client.WithCpudCommand(*cpudCmd),
+		client.WithTimeout(*timeout9P)); err != nil {
 		log.Fatal(err)
-	}
-	if len(*cpudCmd) > 0 {
-		c.WithCpudCommand(*cpudCmd)
-	}
-	if len(*fstab) > 0 {
-		if err := c.AddFSTab(*fstab); err != nil {
-			log.Fatal(err)
-		}
 	}
 	if err := c.Dial(); err != nil {
 		return fmt.Errorf("Dial: got %v, want nil", err)

--- a/server/server_linux_test.go
+++ b/server/server_linux_test.go
@@ -133,7 +133,10 @@ func TestDaemonSession(t *testing.T) {
 
 	t.Logf("HostName %q, IdentityFile %q, command %v", host, kf, os.Args[0])
 	client.V = t.Logf
-	c := client.Command(host, os.Args[0], "-remote", "ls", "-l").WithPrivateKeyFile(kf).WithPort(port).WithRoot(d).WithNameSpace(d)
+	c := client.Command(host, os.Args[0], "-remote", "ls", "-l")
+	if err := c.SetOptions(client.WithPrivateKeyFile(kf), client.WithPort(port), client.WithRoot(d), client.WithNameSpace(d)); err != nil {
+		t.Fatalf("SetOptions: %v != nil", err)
+	}
 	if err := c.Dial(); err != nil {
 		t.Fatalf("Dial: got %v, want nil", err)
 	}
@@ -218,7 +221,10 @@ func TestDaemonConnect(t *testing.T) {
 		t.Fatalf(`cfg.Get("server", "IdentityFile"): (%q, %v) != (afilename, nil`, kf, err)
 	}
 	t.Logf("HostName %q, IdentityFile %q", host, kf)
-	c := client.Command(host, os.Args[0]+" -test.run TestDaemonConnectHelper -test.v --", "date").WithPrivateKeyFile(kf).WithPort(port).WithRoot("/").WithNameSpace("")
+	c := client.Command(host, os.Args[0]+" -test.run TestDaemonConnectHelper -test.v --", "date")
+	if err := c.SetOptions(client.WithPrivateKeyFile(kf), client.WithPort(port), client.WithRoot("/"), client.WithNameSpace("")); err != nil {
+		t.Fatalf("SetOptions: %v != nil", err)
+	}
 	c.Env = append(c.Env, "GO_WANT_DAEMON_HELPER_PROCESS=1")
 	if err := c.Dial(); err != nil {
 		t.Fatalf("Dial: got %v, want nil", err)


### PR DESCRIPTION
At some point I got into Rust habits (in part because of a Go code review
on a totally different project, as it happens) and was using a more Rust style
for options:
c := client.Command(...).WithThis(a).WithThat(b)

That's not really how it should be done, and I had forgotten, but a look
at u-root (see the find package in u-root) made me realize the mistake.

Further, unlike Rust, failing out of those With* things gets nasty,
because Go doesn't have anything like the Rust Result and things like
the Rust ? operator. In one case, I've seen people scarfing the error
value away in the struct, and checking the error and exiting With functions
instantly if the error is set, and checking the error in the struct at the end,
and using that as an error value, and oh please make it stop.

This is not to say one way is unambigously better.
Rust has greater complexity to go with its extra capability.
Go has greater simplicity to go with its slightly greater inconvenience.
Go makes writing and using new Set functions easy, in or out of the package.

Anyway:
Add the Set type to the client package:
type Set func(*Cmd) error

Change the With functions and use as follows:
c := client.Command(host, args...)

Add a new function, SetOptionsin client:
func (c*Cmd) SetOptions(...Set) error

to be used as follows:
if err := c.SetOptions(client.WithThis, client.WithThat, ...); err != nil

In actual use, this turns out to be an improvement.

This is all in preparation for enabling use of the vsock network type.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>