### PR TITLE
Change all uses of 23 to 17010

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker network create cpud
 # If you ran docker before, you need to remove the
 # old identity.
 docker rm cpud_test
-docker run --mount type=bind,source=$KEY.pub,target=/key.pub --mount type=bind,source=$KEY,target=/key --name cpud_test --privileged=true -t -i -p 23:23 rminnich/cpu:latest
+docker run --mount type=bind,source=$KEY.pub,target=/key.pub --mount type=bind,source=$KEY,target=/key --name cpud_test --privileged=true -t -i -p 17010:17010 rminnich/cpu:latest
 ```
 
 Note: once the container is done, if you want to run it again with the
@@ -158,7 +158,7 @@ for convenience):
 ```
 Host h
 	HostName honeycomb
-	Port 23
+	Port 17010
 	User root
 	IdentityFile ~/.ssh/apu2_rsa
 ```

--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,6 @@ const (
 	// the sshd has forked a server for us and it's waiting to be
 	// told what to do.
 	defaultTimeOut   = time.Duration(100 * time.Millisecond)
-	defaultPort      = "23"
 	DefaultNameSpace = "/lib:/lib64:/usr:/bin:/etc:/home"
 )
 
@@ -109,7 +108,7 @@ func Command(host string, args ...string) *Cmd {
 		Host:     host,
 		HostName: GetHostName(host),
 		Args:     args,
-		Port:     defaultPort,
+		Port:     DefaultPort,
 		Timeout:  defaultTimeOut,
 		Row:      row,
 		Col:      col,

--- a/client/cpu_test.go
+++ b/client/cpu_test.go
@@ -72,9 +72,9 @@ Host apu2
 	}{
 		// Can't really test this atm.
 		//{"apu2", "", "2222"},
-		{"apu2", "23", "23"},
+		{"apu2", "17010", "17010"},
 		// This test ensures we never default to port 22
-		{"bogus", "", "23"},
+		{"bogus", "", "17010"},
 		{"bogus", "2222", "2222"},
 	} {
 		got, err := GetPort(test.host, test.port)

--- a/client/fns.go
+++ b/client/fns.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// DefaultPort is the default cpu port.
-	DefaultPort = "23"
+	DefaultPort = "17010"
 )
 
 var (

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -27,7 +27,7 @@ import (
 	ossh "golang.org/x/crypto/ssh"
 )
 
-const defaultPort = "23"
+const defaultPort = "17010"
 
 var (
 	defaultKeyFile = filepath.Join(os.Getenv("HOME"), ".ssh/cpu_rsa")

--- a/cmds/cpu/doc.go
+++ b/cmds/cpu/doc.go
@@ -107,7 +107,7 @@
 //           If you are cpu'ing from, eg., x86 to arm, you might
 //           use, e.g., /amd64
 //     -sp string
-//          remote port, default 23
+//          remote port, default 17010
 //     -srv string
 //           what server to run (default none; use internal)
 //     -timeout9p time.Duration
@@ -132,7 +132,7 @@
 // We can turn these off at some point but for now, in early days, we may want them.
 // Note that these messages come from the remote side.
 // cpu to a machine with bash as your shell and run a command
-//   cpu -sp 23 date
+//   cpu -sp 17010 date
 //     2019/05/17 16:53:22 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
 //     2019/05/17 16:53:22 Mounted /tmp/cpu/lib on /lib
 //     2019/05/17 16:53:22 Mounted /tmp/cpu/lib64 on /lib64
@@ -144,7 +144,7 @@
 // cpu to a machine and run $SHELL (since no arguments were given)
 // NOTE: $SHELL is NOT installed on the remote machine! It (and all its .so's and . files)
 // come from the local machine.
-// cpu sp -23
+// cpu sp -17010
 //    2019/05/17 16:58:04 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
 //    2019/05/17 16:58:04 Mounted /tmp/cpu/lib on /lib
 //    2019/05/17 16:58:04 Mounted /tmp/cpu/lib64 on /lib64

--- a/cmds/cpud/cpuddoc.go
+++ b/cmds/cpud/cpuddoc.go
@@ -40,7 +40,7 @@
 //
 // as a single process for one cpu session, i.e. the old plan 9 cpu -r model
 //
-// as a deamon, listening on port 23 or other well known port,
+// as a deamon, listening on port 17010 or other well known port,
 // forking single cpu sessions, as does sshd.
 //
 // as an init process, i.e. PID 1, which sets up local file systems,

--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -19,13 +19,13 @@ var (
 	// For the ssh server part
 	hostKeyFile = flag.String("hk", "" /*"/etc/ssh/ssh_host_rsa_key"*/, "file for host key")
 	pubKeyFile  = flag.String("pk", "key.pub", "file for public key")
-	port        = flag.String("sp", "23", "cpu default port")
+	port        = flag.String("sp", "17010", "cpu default port")
 
 	debug     = flag.Bool("d", true, "enable debug prints")
 	runAsInit = flag.Bool("init", false, "run as init (Debug only; normal test is if we are pid 1")
 	v         = func(string, ...interface{}) {}
 	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
-	network   = flag.String("network", "tcp", "network to use")
+	network   = flag.String("net", "tcp", "network to use")
 	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
 	klog      = flag.Bool("klog", false, "Log cpud messages in kernel log, not stdout")
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY lib64 /lib64
 COPY root /root
 
 # Export necessary port
-EXPOSE 23
+EXPOSE 17010
 
 # Command to run
 ENTRYPOINT ["/bin/cpud"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,7 +19,7 @@ cat:
 
 rundocker:
 	-docker rm cpud_test
-	docker run --mount type=bind,source=$(PWD)/key.pub,target=/key.pub --mount type=bind,source=$(PWD)/key,target=/key --name cpud_test --privileged=true -t -i -p 23:23 $(IMAGE)
+	docker run --mount type=bind,source=$(PWD)/key.pub,target=/key.pub --mount type=bind,source=$(PWD)/key,target=/key --name cpud_test --privileged=true -t -i -p 17010:17010 $(IMAGE)
 
 run:
 	@echo ===================================================

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultPort = "23"
+	defaultPort = "17010"
 )
 
 var (


### PR DESCRIPTION
17010 is now the IANA registered service for cpu.

The service name is ncpu, transport tcp.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>