### PR TITLE
cpud: make clear how to run as not pid 1

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -54,6 +54,6 @@ func main() {
 			log.Fatalf("CPUD(as remote):%v", err)
 		}
 	default:
-		log.Fatal("CPUD:can only run as remote or pid 1")
+		log.Fatal("CPUD: I'm designed to run as remote or pid 1. Pass `-init` explicitly to run anyway, mostly suitable for debugging.")
 	}
 }


### PR DESCRIPTION
The current error confuses people who want to try out `cpud` from a running system.
This changes the phrasing to point out that while designed for pid 1, `cpud` can still be run with `-init`.