### PR TITLE
Add vsock support to cpud and cpu client package

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,37 @@ b92a3576229b   ubuntu    "/home/rminnich/go/b…"   9 seconds ago   Up 9 seconds
 
 Even though the binaries themselves are running on the remote ARM system.
 
+## Testing with vsock
+
+Vsock is a useful transport layer available in Linux, and support by at least QEMU.
+
+We use the mdlayher/vsock package.
+
+In the cpu and cpud, the switch
+```
+-net vsock
+```
+will enable vsock.
+
+In the host kernel, you need ```vhost_vsock``` module:
+```
+sudo modprobe vhost_vsock
+```
+.
+
+When starting qemu, add
+```
+-device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=3
+```
+to the command line. The '3' is arbitrary; it just needs to be agreed upon on both sides.
+
+When running a cpu command, the host name is the vsock guest-cid you specified in qemu:
+```
+cpu -net vsock 3 date
+```
+
+If you want a different port, you can use the same -sp switch you use for other network types.
+
 ## Summary
 The cpu command makes using small embedded systems dramatically easier. There is no need to install
 a distro, or juggle distros; there is no need to scp files back and forth; just run commands

--- a/TESTCPU
+++ b/TESTCPU
@@ -1,33 +1,63 @@
 #!/bin/bash
 set -e
-# You will need to put your host key and private key somewhere. They will be placed in the proper place in the image.
-u-root \
-	-build=bb \
-	-files  ssh_host_rsa_key:etc/ssh/ssh_host_rsa_key \
-	-initcmd=/bbin/cpud \
-	-files  ~/.ssh/cpu_rsa.pub:key.pub \
-	all \
-	github.com/u-root/cpu/cmds/cpud \
-	github.com/u-root/cpu/cmds/cpu
+SOURCE=${SOURCE:=$HOME/go/src/github.com/u-root/u-root}
+KERNEL=${KERNEL:=$HOME/linuxboot/mainboards/intel/generic/kernel-noinitramfs}
+VMN=${VMN:=42}
+KEY=${KEY:=~/.ssh/cpu_rsa.pub:key.pub}
 
+echo NOTE: WE USED TO RUN CPUD AUTOMAGICALLY
+echo That turned out to be inconvenient for testing
+echo Once the VM is up, you need to run cpud manually
+echo If you want to test cpud as the init, add this line
+echo to the u-root command, along with the other switches.
+echo -initcmd=/bbin/cpud \
+
+# You will need to put your host key and private key somewhere. They will be placed in the proper place in the image.
+#
+# $* is positioned where it is so you can use extra switches like -h or add files via, e.g., -files whatever
+# you can also add non-switch args too.
+# it allows you to configure the initramfs a bit more, with or without switches
+u-root \
+	-files   $KEY \
+	-uroot-source $SOURCE \
+	$* \
+	all \
+	cmds/cpud \
+	cmds/cpu \
+
+echo NOT adding a host key at -files  ssh_host_rsa_key:etc/ssh/ssh_host_rsa_key 
+
+set +e
 sudo /usr/bin/qemu-system-x86_64 -kernel \
-     /home/rminnich/projects/linuxboot/mainboards/intel/generic/kernel-noinitramfs \
+     $KERNEL \
 	-cpu  max \
      -s   \
      -m 1024m \
      -machine q35  \
      -initrd /tmp/initramfs.linux_amd64.cpio \
-    -object rng-random,filename=/dev/urandom,id=rng0 \
-    -device virtio-rng-pci,rng=rng0 \
-     -device e1000,netdev=n1 \
-     -netdev user,id=n1,hostfwd=tcp:127.0.0.1:23-:2222,net=192.168.1.0/24,host=192.168.1.1 \
-     -serial stdio  \
+     -object rng-random,filename=/dev/urandom,id=rng0 \
+     -device virtio-rng-pci,rng=rng0 \
+     -serial /dev/tty  \
      -append earlyprintk=ttyS0,115200\ console=ttyS0 \
+     -device vhost-vsock-pci,guest-cid=42 \
      -monitor /dev/null  \
+     -device virtio-net-pci,netdev=n1 \
+     -netdev user,id=n1,hostfwd=tcp:127.0.0.1:17010-:17010,net=192.168.1.0/24,host=192.168.1.1 \
+     -debugcon file:debug.log -global isa-debugcon.iobase=0x402 \
+     -nographic
      
+reset
      # note we will exit here so the trash below is not a problem
      exit 0
 
+     # two handy utils for testing vsock
+	-files vsock-server \
+	-files vsock-cat \
+
+     -device e1000,netdev=n1 \
+     -device virtio-net-pci,netdev=n1 \
+     -device virtio-net-pci,netdev=mynet0 \
+     -netdev user,id=mynet0,hostfwd=tcp::${VMN}0022-:22,hostfwd=tcp::${VMN}1024-:1024,hostfwd=tcp::${VMN}1234-:1234 \
      # junk
 
      /home/rminnich/projects/linuxboot/linux/arch/x86/boot/bzImage \

--- a/client/fns.go
+++ b/client/fns.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	// We use this ssh because it implements port redirection.
@@ -214,6 +215,20 @@ func GetPort(host, port string) (string, error) {
 	}
 	V("returns %q", p)
 	return p, nil
+}
+
+// vsockIdPort gets a client id and a port from host and port
+// The id and port are uint32.
+func vsockIdPort(host, port string) (uint32, uint32, error) {
+	h, err := strconv.ParseUint(host, 0, 32)
+	if err != nil {
+		return 0, 0, err
+	}
+	p, err := strconv.ParseUint(port, 0, 32)
+	if err != nil {
+		return 0, 0, err
+	}
+	return uint32(h), uint32(p), nil
 }
 
 // Signal implements ssh.Signal

--- a/client/fns_test.go
+++ b/client/fns_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+)
+
+// vsockIdPort gets a client id and a port from host and port
+// The id and port are uint32.
+func TestVsockIdPort(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		host string
+		port string
+		h    uint32
+		p    uint32
+		err  error
+	}{
+		{name: "badhostportn", host: "", port: "", h: 0, p: 0, err: strconv.ErrSyntax},
+		{name: "noport", host: "1", port: "", h: 0, p: 0, err: strconv.ErrSyntax},
+		{name: "nohost", host: "", port: "1", h: 0, p: 0, err: strconv.ErrSyntax},
+		{name: "ok", host: "1", port: "2", h: 1, p: 2, err: nil},
+		{name: "badhostnum", host: "z", port: "2", h: 0, p: 0, err: strconv.ErrSyntax},
+		{name: "ok", host: "0x42", port: "17010", h: 0x42, p: 17010, err: nil},
+	} {
+		h, p, err := vsockIdPort(tt.host, tt.port)
+		if !errors.Is(err, tt.err) || h != tt.h || p != tt.p {
+			t.Errorf("%s:vsockIdPort(%s, %s): (%v, %v, %v) != (%v, %v, %v)", tt.name, tt.host, tt.port, h, p, err, tt.h, tt.p, tt.err)
+		}
+	}
+}

--- a/cmds/cpud/cpuddoc.go
+++ b/cmds/cpud/cpuddoc.go
@@ -20,7 +20,7 @@
 //     -network string
 //           network to use (default "tcp")
 //     -p string
-//           port to use (default "22")
+//           port to use (default "17010")
 //     -port9p string
 //           port9p # on remote machine for 9p mount
 //     -remote

--- a/go.mod
+++ b/go.mod
@@ -8,19 +8,25 @@ require (
 	github.com/kevinburke/ssh_config v1.1.0
 	github.com/u-root/u-root v0.8.0
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
+	golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a
 )
 
-require github.com/hashicorp/errwrap v1.0.0 // indirect
+require (
+	github.com/creack/pty v1.1.11
+	github.com/hashicorp/go-multierror v1.1.1
+	github.com/mdlayher/vsock v1.1.1
+)
 
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/creack/pty v1.1.11
-	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/klauspost/compress v1.10.6 // indirect
 	github.com/klauspost/pgzip v1.2.4 // indirect
+	github.com/mdlayher/socket v0.2.0 // indirect
 	github.com/u-root/uio v0.0.0-20210528114334-82958018845c // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/vishvananda/netlink v1.1.1-0.20211118161826-650dca95af54 // indirect
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.2.1-0.20200615092505-5d8a91de9ae3/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
 github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=
@@ -98,6 +101,10 @@ github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcK
 github.com/mdlayher/netlink v1.1.1/go.mod h1:WTYpFb/WTvlRJAyKhZL5/uy69TDDpHHu2VZmb2XgV7o=
 github.com/mdlayher/raw v0.0.0-20190606142536-fef19f00fc18/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
 github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
+github.com/mdlayher/socket v0.2.0 h1:EY4YQd6hTAg2tcXF84p5DTHazShE50u5HeBzBaNgjkA=
+github.com/mdlayher/socket v0.2.0/go.mod h1:QLlNPkFR88mRUNQIzRBMfXxwKal8H7u1h3bL1CV+f0E=
+github.com/mdlayher/vsock v1.1.1 h1:8lFuiXQnmICBrCIIA9PMgVSke6Fg6V4+r0v7r55k88I=
+github.com/mdlayher/vsock v1.1.1/go.mod h1:Y43jzcy7KM3QB+/FK15pfqGxDMCMzUXWegEfIbSM18U=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -179,6 +186,7 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190419010253-1f3472d942ba/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -188,12 +196,14 @@ golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -224,8 +234,9 @@ golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a h1:ppl5mZgokTT8uPkmYOyEUmPTr3ypaKkg5eFOGrAmxxE=
+golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 h1:EC6+IGYTjPpRfv9a2b/6Puw0W+hLtAhkV1tPsXhutqs=
 golang.org/x/term v0.0.0-20210317153231-de623e64d2a6/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
vsock is a simpler networking path for virtual machine guests.

It needs no emulated hardware or IP stacks. It is a lot like
networking over a serial line. There are fewer moving parts
and hence less to go wrong.

One thing that can go wrong is your kernel is broken, e.g. ubuntu
5.8, and in that case you will get connection timeouts. To fix
a problem like this, update ubuntu or use something else. Ubuntu
22 is known to work; ubuntu 20 is known to not work.

Sadly, vsock is not in the net package, so the code is more complex
than it ought to be.

To use vsock on cpud:
cpud -net vsock [... args]

cpud will listen on any CID, so can be reached even from the VM itself.

To use it on the client:
./cpu -net vsock [other switches] vsock-client-id [other cpu args]

e.g., if one starts qemu with the following vsock switches:
-device vhost-vsock-pci,guest-cid=42

The vsock-client-id above would be 42.

For example, when qemu is started as above, then the cpud command is
cpud -net vsock -init

and the cpu command can be (assuming you are not using a default
key):
./cpu -key ~/.ssh/cpu_rsa -net vsock 42 date

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>