### PR TITLE
Add an "inetd" mode for cpud

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -44,6 +44,12 @@ func main() {
 	args := flag.Args()
 	switch {
 	case *runAsInit:
+		if err := commonsetup(); err != nil {
+			log.Fatal(err)
+		}
+		if err := initsetup(); err != nil {
+			log.Fatal(err)
+		}
 		if err := serve(); err != nil {
 			log.Fatal(err)
 		}
@@ -54,6 +60,12 @@ func main() {
 			log.Fatalf("CPUD(as remote):%v", err)
 		}
 	default:
-		log.Fatal("CPUD: I'm designed to run as remote or pid 1. Pass `-init` explicitly to run anyway, mostly suitable for debugging.")
+		log.Printf("cpud: running as a server (a.k.a. starter of cpud's for sessions")
+		if err := commonsetup(); err != nil {
+			log.Fatal(err)
+		}
+		if err := serve(); err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -34,10 +34,7 @@ func hang() {
 	log.Printf("done hang")
 }
 
-func serve() error {
-	if err := unix.Mount("cpu", "/tmp", "tmpfs", 0, ""); err != nil {
-		log.Printf("CPUD:Warning: tmpfs mount on /tmp (%v) failed. There will be no 9p mount", err)
-	}
+func commonsetup() error {
 	if *debug {
 		v = log.Printf
 		if *klog {
@@ -45,7 +42,13 @@ func serve() error {
 			v = ulog.KernelLog.Printf
 		}
 	}
+	return nil
+}
 
+func initsetup() error {
+	if err := unix.Mount("cpu", "/tmp", "tmpfs", 0, ""); err != nil {
+		log.Printf("CPUD:Warning: tmpfs mount on /tmp (%v) failed. There will be no 9p mount", err)
+	}
 	if err := cpuSetup(); err != nil {
 		log.Printf("CPUD:CPU setup error with cpu running as init: %v", err)
 	}
@@ -68,7 +71,11 @@ func serve() error {
 			continue
 		}
 	}
-	verbose("Kicked off startup jobs, now serve ssh")
+	verbose("Kicked off startup jobs, now serve cpu sessions")
+	return nil
+}
+
+func serve() error {
 	s, err := server.New(*pubKeyFile, *hostKeyFile)
 	if err != nil {
 		log.Printf(`New(%q, %q): %v != nil`, *pubKeyFile, *hostKeyFile, err)


### PR DESCRIPTION
People are looking at running cpud manually, after the system is fully booted.

cpud will now have a default behavior when it is invoked with no mode: it will
run as "inetd." It will not try to set up cgroups, loopback interfaces, or a
process reaper: that is for init to do.

This will make it easier to run cpud on systems which are past runlevel 1.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>