### PR TITLE
Change all uses of 127.0.0.1 with "localhost"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -276,7 +276,7 @@ func (c *Cmd) Dial() error {
 	// Note: cl.Listen returns a TCP listener with network "tcp"
 	// or variants. This lets us use a listen deadline.
 	if c.Ninep {
-		l, err := cl.Listen("tcp", "127.0.0.1:0")
+		l, err := cl.Listen("tcp", "localhost:0")
 		if err != nil {
 			return fmt.Errorf("cpu client listen for forwarded 9p port %v", err)
 		}

--- a/server/server_other.go
+++ b/server/server_other.go
@@ -27,7 +27,7 @@ func (s *Session) Namespace() (error, error) {
 	v("CPUD:namespace is %q", s.binds)
 
 	// Connect to the socket, return the nonce.
-	a := net.JoinHostPort("127.0.0.1", s.port9p)
+	a := net.JoinHostPort("localhost", s.port9p)
 	v("CPUD:Dial %v", a)
 	so, err := net.Dial("tcp", a)
 	if err != nil {

--- a/session/session_linux.go
+++ b/session/session_linux.go
@@ -58,7 +58,7 @@ func (s *Session) Namespace() (error, error) {
 	v("CPUD:namespace is %q", s.binds)
 
 	// Connect to the socket, return the nonce.
-	a := net.JoinHostPort("127.0.0.1", s.port9p)
+	a := net.JoinHostPort("localhost", s.port9p)
 	v("CPUD:Dial %v", a)
 	so, err := net.Dial("tcp4", a)
 	if err != nil {
@@ -96,8 +96,8 @@ func (s *Session) Namespace() (error, error) {
 	if len(s.mopts) > 0 {
 		opts += "," + s.mopts
 	}
-	v("CPUD: mount 127.0.0.1 on /tmp/cpu 9p %#x %s", flags, opts)
-	if err := unix.Mount("127.0.0.1", "/tmp/cpu", "9p", flags, opts); err != nil {
+	v("CPUD: mount localhost on /tmp/cpu 9p %#x %s", flags, opts)
+	if err := unix.Mount("localhost", "/tmp/cpu", "9p", flags, opts); err != nil {
 		return nil, fmt.Errorf("9p mount %v", err)
 	}
 	v("CPUD: mount done")


### PR DESCRIPTION
For systems with no IPv4 stack.

In particular, the client.go connection tells cpud to connect to
127.0.0.1.  But if there is no 127.0.0.1, you'll get an error like:

	SSH error Dial: cpu client listen for forwarded 9p port ssh:
	tcpip-forward request denied by peer

Signed-off-by: Barret Rhoden <brho@google.com>