### PR TITLE
Maybe deal with PWD is not a directory in the remote namespace

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -200,6 +200,11 @@ func (s *Session) Run() error {
 	v("CPUD:runRemote: command is %q", s.args)
 	c := exec.Command(s.cmd, s.args...)
 	c.Stdin, c.Stdout, c.Stderr, c.Dir = s.Stdin, s.Stdout, s.Stderr, os.Getenv("PWD")
+	dirInfo, err := os.Stat(c.Dir)
+	if err != nil || !dirInfo.IsDir() {
+		log.Printf("CPUD: your $PWD %s is not in the remote namespace", c.Dir)
+		return os.ErrNotExist
+	}
 	err = c.Run()
 	v("CPUD:Run %v returns %v", c, err)
 	if err != nil {


### PR DESCRIPTION
PWD on the cpu client side might not exist in the namespace created by
cpud -remote.  For instance, if you run cpu from /tmp/foo, and that is
not exported in the 9p namespace= parameter, the command will fail with
something like:

	CPUD(as remote):chdir /tmp/foo: no such file or directory

Signed-off-by: Barret Rhoden <brho@google.com>