### PR TITLE
Revert "Use /proc/self/exe on Linux for cpud"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -129,7 +129,7 @@ func Command(host string, args ...string) *Cmd {
 		// Also, there is the nagging concern that we're not
 		// totally proper yet on the security issues
 		// around letting users run arbitrary binaries.
-		cmd: osDefaultCpudCmd,
+		cmd: "cpud -remote",
 	}
 }
 

--- a/client/cpu_darwin.go
+++ b/client/cpu_darwin.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hugelgupf/p9/p9"
 )
 
-const osDefaultCpudCmd = "cpud -remote"
-
 func osflags(fi os.FileInfo, mode p9.OpenFlags) int {
 	flags := int(mode)
 	if fi.IsDir() {

--- a/client/cpu_linux.go
+++ b/client/cpu_linux.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hugelgupf/p9/p9"
 )
 
-const osDefaultCpudCmd = "/proc/self/exe -remote"
-
 func osflags(fi os.FileInfo, mode p9.OpenFlags) int {
 	flags := int(mode)
 	if fi.IsDir() {


### PR DESCRIPTION
Using the /proc/self/exe symlink is a nice idea, but on u-root systems
it resolves to /bbin/bb, which is absolutely not what we want.

This reverts commit c0075b1ce7e8db5669f70b08731e986a397b7c12.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>