### PR TITLE
cmds/cpu: remove termios calls

### DIFF
--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -20,7 +20,6 @@ import (
 
 	config "github.com/kevinburke/ssh_config"
 	"github.com/u-root/cpu/client"
-	"github.com/u-root/u-root/pkg/termios"
 	"github.com/u-root/u-root/pkg/ulog"
 
 	// We use this ssh because it can unpack password-protected private keys.
@@ -184,10 +183,6 @@ func main() {
 			a = "/bin/sh"
 		}
 	}
-	t, err := termios.GetTermios(0)
-	if err != nil {
-		log.Fatal("Getting Termios")
-	}
 
 	*keyFile = getKeyFile(host, *keyFile)
 	*port = getPort(host, *port)
@@ -202,11 +197,5 @@ func main() {
 			e = sshErr.ExitStatus()
 		}
 		defer os.Exit(e)
-	}
-	if err := termios.SetTermios(0, t); err != nil {
-		// Never make this a log.Fatal, it might
-		// interfere with the exit handling
-		// for errors from the remote process.
-		log.Print(err)
 	}
 }


### PR DESCRIPTION
Now that the u-root termios pkg is fixed as of b0da363052a2724a46a72ec11d323e6f646529a9,
we no longer need the calls in cpu.go to get and reset the terminal.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>