### PR TITLE
Allow Listen() on unix domain sockets

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -276,6 +276,8 @@ func (c *Cmd) Dial() error {
 		}
 		addr = fmt.Sprintf("%#x:%d", id, port)
 		conn, err = vsock.Dial(id, port, nil)
+	case "unix", "unixgram", "unixpacket":
+		conn, err = net.Dial(c.network, c.Port)
 	default:
 		addr = net.JoinHostPort(c.HostName, c.Port)
 		conn, err = net.Dial(c.network, addr)

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -93,6 +93,8 @@ func serve() error {
 		if err == nil {
 			ln, err = vsock.ListenContextID(any, uint32(p), nil)
 		}
+	case "unix", "unixgram", "unixpacket":
+		ln, err = net.Listen(*network, *port)
 	default:
 		ln, err = net.Listen(*network, ":"+*port)
 	}


### PR DESCRIPTION
You can't have the ':' in the port name.

Tested:
./cpud -net unix -sp "@foobar" &
./cpu -net unix -sp '@foobar' NOHOST date
Tue Aug  2 16:01:42 EDT 2022

It's annoying, but the cpu command expects a hostname in its parsing.
With a unix domain socket, there is no hostname.  Hence the garbage
NOHOST parameter.  Otherwise "date" is the hostname parameter!

Signed-off-by: Barret Rhoden <brho@google.com>