### PR TITLE
Add -tmpMnt to change namespace mount point

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -74,6 +74,8 @@ type Cmd struct {
 	// Ninep determines if client will run a 9P server
 	Ninep bool
 
+	TmpMnt string
+
 	nonce   nonce
 	network string // This is a variable but we expect it will always be tcp
 	port9p  uint16 // port on which we serve 9p
@@ -183,6 +185,14 @@ func WithFSTab(fstab string) Set {
 			return fmt.Errorf("Reading fstab: %w", err)
 		}
 		c.FSTab = string(b)
+		return nil
+	}
+}
+
+// WithTempMount sets the private namespace mount point.
+func WithTempMount(tmpMnt string) Set {
+	return func(c *Cmd) error {
+		c.TmpMnt = tmpMnt
 		return nil
 	}
 }
@@ -474,6 +484,8 @@ func (c *Cmd) Dial() error {
 			c.Env = append(c.Env, "CPU_NAMESPACE="+c.NameSpace)
 		}
 		V("Set NONCE; set NAMESPACE to %q", "CPU_NAMESPACE="+c.NameSpace)
+		c.Env = append(c.Env, "CPU_TMPMNT="+c.TmpMnt)
+		V("Set CPU_TMPMNT to %q", "CPU_TMPMNT="+c.TmpMnt)
 		go func(l net.Listener) {
 			if err := c.srv(l); err != nil {
 				log.Printf("9p server error: %v", err)

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -45,8 +45,10 @@ var (
 	timeout9P   = flag.String("timeout9p", "100ms", "time to wait for the 9p mount to happen.")
 	ninep       = flag.Bool("9p", true, "Enable the 9p mount in the client")
 	mdns        = flag.Bool("mdns", false, "I want to use default mdns query (no specified hostname)")
-	v           = func(string, ...interface{}) {}
-	dumpWriter  *os.File
+	tmpMnt      = flag.String("tmpMnt", "/tmp", "Mount point of the private namespace.")
+
+	v          = func(string, ...interface{}) {}
+	dumpWriter *os.File
 )
 
 func verbose(f string, a ...interface{}) {
@@ -149,6 +151,7 @@ func newCPU(host string, args ...string) error {
 		client.WithFSTab(*fstab),
 		client.WithCpudCommand(*cpudCmd),
 		client.WithNetwork(*network),
+		client.WithTempMount(*tmpMnt),
 		client.WithTimeout(*timeout9P)); err != nil {
 		log.Fatal(err)
 	}

--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -82,7 +82,11 @@ func main() {
 		}
 	case *remote:
 		verbose("server package: Running as remote: args %q, port9p %v", args, *port9p)
-		s := session.New(*port9p, args[0], args[1:]...)
+		tmpMnt, ok := os.LookupEnv("CPU_TMPMNT")
+		if !ok || len(tmpMnt) == 0 {
+			tmpMnt = "/tmp"
+		}
+		s := session.New(*port9p, tmpMnt, args[0], args[1:]...)
 		if err := s.Run(); err != nil {
 			log.Fatalf("CPUD(as remote):%v", err)
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -33,7 +33,7 @@ func TestRemoteNoNameSpace(t *testing.T) {
 		t.Skipf("Skipping as we are not root")
 	}
 	v = t.Logf
-	s := session.New("", "date")
+	s := session.New("", "/tmp", "date")
 	o, e := &bytes.Buffer{}, &bytes.Buffer{}
 	s.Stdin, s.Stdout, s.Stderr = nil, o, e
 	if err := s.Run(); err != nil {
@@ -102,7 +102,7 @@ func TestDaemonConnectHelper(t *testing.T) {
 		return
 	}
 	t.Logf("As a helper, we are supposed to run %q", args)
-	s := session.New(port9p, args[0], args[1:]...)
+	s := session.New(port9p, "/tmp", args[0], args[1:]...)
 	// Step through the things a server is supposed to do with a session
 	if err := s.Run(); err != nil {
 		log.Fatalf("CPUD(as remote):%v", err)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -11,7 +11,7 @@ import (
 
 // Not sure testing this is a great idea but ... it works so ...
 func TestDropPrivs(t *testing.T) {
-	s := New("", "/bin/true")
+	s := New("", "/tmp", "/bin/true")
 	if err := s.DropPrivs(); err != nil {
 		t.Fatalf("s.DropPrivs(): %v != nil", err)
 	}


### PR DESCRIPTION
Some applications may need to access the original contents in `/tmp` directory of the local host. Adding `-tmpMnt` to allow changing the private namespace mount point to avoid conflict.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>