### PR TITLE
Remove use of p9.unimplfs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,10 @@ const (
 	// we would like to default to 100ms. This is a lot, considering that at this point,
 	// the sshd has forked a server for us and it's waiting to be
 	// told what to do.
-	defaultTimeOut   = time.Duration(100 * time.Millisecond)
+	defaultTimeOut = time.Duration(100 * time.Millisecond)
+
+	// DefaultNameSpace is the default used if the user does not request
+	// something else.
 	DefaultNameSpace = "/lib:/lib64:/usr:/bin:/etc:/home"
 )
 
@@ -99,7 +102,7 @@ func Command(host string, args ...string) *Cmd {
 
 	col, row := 80, 40
 	if w, err := termios.GetWinSize(0); err != nil {
-		log.Printf("Can not get winsize: %v; assuming %dx%d and non-interactive", err, col, row)
+		verbose("Can not get winsize: %v; assuming %dx%d and non-interactive", err, col, row)
 	} else {
 		hasTTY = true
 		col, row = int(w.Col), int(w.Row)
@@ -133,6 +136,7 @@ func Command(host string, args ...string) *Cmd {
 	}
 }
 
+// Set is the type of function used to set options in SetOptions.
 type Set func(*Cmd) error
 
 // With9P enables the 9P2000 server in cpu.
@@ -159,7 +163,7 @@ func WithNameSpace(ns string) Set {
 	}
 }
 
-// AddFSTab reads a file for the FSTab member.
+// WithFSTab reads a file for the FSTab member.
 func WithFSTab(fstab string) Set {
 	return func(c *Cmd) error {
 		if len(fstab) == 0 {
@@ -174,7 +178,7 @@ func WithFSTab(fstab string) Set {
 	}
 }
 
-// SetTimeout sets the 9p timeout.
+// WithTimeout sets the 9p timeout.
 func WithTimeout(timeout string) Set {
 	return func(c *Cmd) error {
 		d, err := time.ParseDuration(timeout)
@@ -234,7 +238,7 @@ func WithNetwork(network string) Set {
 	}
 }
 
-// SetPort sets the port in the Cmd.
+// WithPort sets the port in the Cmd.
 // It calls GetPort with the passed-in port
 // before assigning it.
 func WithPort(port string) Set {

--- a/client/cpu9p.go
+++ b/client/cpu9p.go
@@ -22,14 +22,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/hugelgupf/p9/fsimpl/templatefs"
 	"github.com/hugelgupf/p9/p9"
 )
 
 // cpu9p is a p9.Attacher.
 type cpu9p struct {
 	p9.DefaultWalkGetAttr
-	templatefs.NoopFile
 
 	path string
 	file *os.File
@@ -269,4 +267,30 @@ func (l *cpu9p) UnlinkAt(name string, flags uint32) error {
 	err := os.Remove(f)
 	verbose("UnlinkAt(%q=(%q, %q), %#x): (%v)", f, l.path, name, flags, err)
 	return err
+}
+
+// Mknod implements p9.File.Mknod.
+func (*cpu9p) Mknod(name string, mode p9.FileMode, major uint32, minor uint32, _ p9.UID, _ p9.GID) (p9.QID, error) {
+	verbose("Mknod: not implemented")
+	return p9.QID{}, syscall.ENOSYS
+}
+
+// Rename implements p9.File.Rename.
+func (*cpu9p) Rename(directory p9.File, name string) error {
+	verbose("Rename: not implemented")
+	return syscall.ENOSYS
+}
+
+// RenameAt implements p9.File.RenameAt.
+func (*cpu9p) RenameAt(oldname string, newdir p9.File, newname string) error {
+	verbose("RenameAt: not implemented")
+	return syscall.ENOSYS
+}
+
+// StatFS implements p9.File.StatFS.
+//
+// Not implemented.
+func (*cpu9p) StatFS() (p9.FSStat, error) {
+	verbose("StatFS: not implemented")
+	return p9.FSStat{}, syscall.ENOSYS
 }

--- a/client/cpu9p_unix_test.go
+++ b/client/cpu9p_unix_test.go
@@ -236,3 +236,27 @@ func Test9pUnlinkat(t *testing.T) {
 		t.Errorf("After UnlinkAt file: os.Stat(%q): got nil, want err", f)
 	}
 }
+
+func Test9pRenameAt(t *testing.T) {
+	d := t.TempDir()
+	f := filepath.Join(d, "a")
+	if err := ioutil.WriteFile(f, []byte("hi"), 0666); err != nil {
+		t.Fatalf(`ioutil.WriteFile(%q, "hi", 0666): %v != nil`, f, err)
+	}
+	c := &cpu9p{
+		path: filepath.Join(d, "nd"),
+	}
+	if err := os.Mkdir(c.path, 0777); err != nil {
+		t.Fatalf("Mkdir(%q, 0777): %v != nil", c.path, err)
+	}
+	oldPath := &cpu9p {
+		path: d,
+	}
+	if err := oldPath.RenameAt("a", c, "z"); err != nil {
+		t.Errorf("RenameAt(%q, %q, \"z\"): %v != nil", f, c.path, err)
+	}
+	newFile := filepath.Join(c.path, "z")
+	if _, err := os.Stat(newFile); err != nil {
+		t.Errorf("os.Stat(%q): %v != nil", newFile, err)
+	}
+}

--- a/client/doc.go
+++ b/client/doc.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package cpu provides an exec.Command and ssh like interface for cpu sessions.
+// Package client provides an exec.Command and ssh like interface for cpu sessions.
 // It attempts to cleave as much as possible to the original.
 // The choice between options and environment variables mirrors this effort.
 // For example, the namespace for the remote process is an environment variable,


### PR DESCRIPTION
It has proven to be very confusing to use unimplfs, since it shortstops T requests silently. This was, when cpu is run with -d, users will see the messages.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>