### PR TITLE
Fix build of cpu in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN mkdir -p /app/root
 RUN mkdir -p /app/lib64 
 RUN CGO_ENABLED=0 go build -o cpud ./cmds/cpud/.
-RUN CGO_ENABLED=0 GOBIN=`pwd` go install github.com/u-root/cpu/cmds/cpu
+RUN CGO_ENABLED=0 go build -o cpu ./cmds/cpu/.
 RUN CGO_ENABLED=0 GOBIN=`pwd` go install  github.com/u-root/u-root/cmds/core/date
 RUN CGO_ENABLED=0 GOBIN=`pwd` go install  github.com/u-root/u-root/cmds/core/cat
 


### PR DESCRIPTION
The Dockerfile was pulling from a pre-built cpu client, but we have the source, and if I'm testing the client, I want to include my changes in the docker build versus pulling the upstream pre-build binary.

Signed-off-by: Eric Van Hensbergen <eric.vanhensbergen@arm.com>