### PR TITLE
Add sorting to dnssd client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -290,10 +291,13 @@ func vsockDial(host, port string) (net.Conn, string, error) {
 
 }
 
-// check that mdns response has all required attributes
-func mdns_required(src map[string]string, req map[string][]string) bool {
+// check that dnssd response has all required attributes
+func ds_required(src map[string]string, req map[string][]string) bool {
 	for k, _ := range req {
 		// ignore sort criteria since they are optional
+		if k == "sort" {
+			continue
+		}
 		switch req[k][0][0] {
 		case '<':
 			fallthrough
@@ -364,7 +368,7 @@ func DsParse(uri string) (dsQuery, error) {
 	}
 
 	if u.Scheme != "dnssd" {
-		return result, fmt.Errorf("Not an mdns dns-sd URI")
+		return result, fmt.Errorf("Not a dns-sd URI")
 	}
 
 	// following dns-sd URI conventions from CUPS
@@ -388,16 +392,122 @@ func DsParse(uri string) (dsQuery, error) {
 	return result, nil
 }
 
+type dsLessFunc func(p1, p2 *dnssd.BrowseEntry) bool
+type dsMultiSorter struct {
+	entries []dnssd.BrowseEntry
+	less    []dsLessFunc
+}
+
+func (ms *dsMultiSorter) Len() int {
+	return len(ms.entries)
+}
+
+func (ms *dsMultiSorter) Swap(i, j int) {
+	ms.entries[i], ms.entries[j] = ms.entries[j], ms.entries[i]
+}
+
+// Less is part of sort.Interface. It is implemented by looping along the
+// less functions until it finds a comparison that discriminates between
+// the two items (one is less than the other). Note that it can call the
+// less functions twice per call. We could change the functions to return
+// -1, 0, 1 and reduce the number of calls for greater efficiency: an
+// exercise for the reader.
+func (ms *dsMultiSorter) Less(i, j int) bool {
+	p, q := &ms.entries[i], &ms.entries[j]
+	// Try all but the last comparison.
+	var k int
+	for k = 0; k < len(ms.less)-1; k++ {
+		less := ms.less[k]
+		switch {
+		case less(p, q):
+			// p < q, so we have a decision.
+			return true
+		case less(q, p):
+			// p > q, so we have a decision.
+			return false
+		}
+		// p == q; try the next comparison.
+	}
+	// All comparisons to here said "equal", so just return whatever
+	// the final comparison reports.
+	return ms.less[k](p, q)
+}
+
+// generate sort functions for dnssd BrowseEntry based on txt key
+func dsGenSortTxt(key string, operator byte) dsLessFunc {
+	return func(c1, c2 *dnssd.BrowseEntry) bool {
+		switch operator {
+		case '=': // key existence prioritizes entry
+			if len(c1.Text[key]) > len(c2.Text[key]) {
+				return true
+			} else {
+				return false
+			}
+		case '!': // key existence deprioritizes entry
+			if len(c1.Text[key]) < len(c2.Text[key]) {
+				return true
+			} else {
+				return false
+			}
+		}
+		n1, err := strconv.ParseFloat(c1.Text[key], 10)
+		if err != nil {
+			V("Bad format in entry TXT")
+			return false
+		}
+		n2, err := strconv.ParseFloat(c2.Text[key], 10)
+		if err != nil {
+			V("Bad format in entry TXT")
+			return false
+		}
+		switch operator {
+		case '<':
+			if n1 < n2 {
+				return true
+			}
+		case '>':
+			if n1 > n2 {
+				return true
+			}
+		default:
+			V("Bad operator")
+		}
+		return false
+	}
+}
+
+// perform numeric sort based on a particular key (assumes numeric values)
+func dsSort(req map[string][]string, entries []dnssd.BrowseEntry) {
+	if len(req["sort"]) == 0 {
+		return
+	}
+	ms := &dsMultiSorter{
+		entries: entries,
+	}
+	// generate a sort function list based on sort entry
+	for _, element := range req["sort"] {
+		var operator byte
+		operator = '<' // default to use if no operator
+		switch element[0] {
+		case '<', '>', '=', '!':
+			operator = element[0]
+			if len(element) < 2 {
+				V("dnssd: Poorly configured comparison in sort %s", element)
+				return
+			}
+			element = element[1:]
+		}
+		ms.less = append(ms.less, dsGenSortTxt(element, operator))
+	}
+	sort.Sort(ms)
+}
+
 // lookup based on hostname, return resolved host, port, network, and error
 // uri currently supported dnssd://domain/_service._network/instance?reqkey=reqvalue
 // default for domain is local, first path element is _ncpu._tcp, and instance is wildcard
 // can omit to underspecify, e.g. dnssd:?arch=arm64 to pick any arm64 cpu server
 func DsLookup(query dsQuery) (string, string, error) {
-	var (
-		err error
-	)
-
-	timeout := 5 * time.Second
+	timeout := 1 * time.Second
 	timeFormat := "15:04:05.000"
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -415,7 +525,7 @@ func DsLookup(query dsQuery) (string, string, error) {
 		V("%s	Add	%s	%s	%s	%s (%s)\n", time.Now().Format(timeFormat), e.IfaceName, e.Domain, e.Type, e.Name, e.IPs)
 		// check requirement
 		V("Checking ", e.Text, query.Text)
-		if mdns_required(e.Text, query.Text) {
+		if ds_required(e.Text, query.Text) {
 			respCh <- &e
 		}
 	}
@@ -432,14 +542,26 @@ func DsLookup(query dsQuery) (string, string, error) {
 		respCh <- nil
 	}()
 
-	e := <-respCh
+	var responses []dnssd.BrowseEntry
+	for {
+		e := <-respCh
+		if e == nil {
+			break
+		}
+		responses = append(responses, *e)
+	}
 
-	// cancel()
-	if e == nil {
+	cancel() // do we still do this?
+	V("dnssd: Got %d responses", len(responses))
+
+	if len(responses) == 0 {
 		return "", "", fmt.Errorf("dnssd found no suitable service")
 	}
 
-	return e.Host, strconv.Itoa(e.Port), err
+	dsSort(query.Text, responses)
+
+	e := responses[0]
+	return e.Host, strconv.Itoa(e.Port), nil
 }
 
 // Dial implements ssh.Dial for cpu.


### PR DESCRIPTION
_NOTE_: This change is dependent on a previous pull request which added comparators which is also included in this patch.  I will rebase once that patch is accepted so this PR can be clean. 

You can now sort on various meta-data.  Default is to sort numerically
ascending, but you can override with comparitors (<, >, !, or =).
In the case of ! of = they will sort based on the existence (or
non-existence of a key).

Since we are now picking amongst a list, there is a built in delay of 1
second to gather results before sorting.

e.g. /bin/cpu dnssd:?sort=order\&sort==eorder\&sort=\<gtorder

Signed-off-by: Eric Van Hensbergen <eric.vanhensbergen@arm.com>