### PR TITLE
Update documentation for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,11 @@ or if you have installed a version of docker buildx, you can build a multi-arch 
 % docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" --progress plain --pull -t "${USER}/cpu:latest" .
 ```
 
-There is a pre-built version of a multi-arch container here which you can substitute for the next section if you want to try out on arm (either arm64 or arm/v7): 
-```
-ericvh/cpu:latest
-```
-
-### Pre-build Docker container for trying out cpu (on x86 for now)
+### Pre-built Docker container for trying out cpu (on arm64 & amd64 for now)
 
 We have created a docker container so you can try cpu client and server:
 ```
-rminnich/cpu:latest
+ghcr.io/u-root/cpu:main
 ```
 
 It includes both the cpud (server) and cpu (client) commands. In the
@@ -109,21 +104,14 @@ That is how we avoid
 storing keys in the container itself.
 ```
 docker network create cpud
-# If you ran docker before, you need to remove the
-# old identity.
-docker rm cpud_test
-docker run --mount type=bind,source=$KEY.pub,target=/key.pub --mount type=bind,source=$KEY,target=/key --name cpud_test --privileged=true -t -i -p 17010:17010 rminnich/cpu:latest
-```
-
-Note: once the container is done, if you want to run it again with the
-same named, cpud_test, you must:
-```
-docker rm cpud_test
+# If you ran docker before and it failed in some way, you may need to remove the
+# old identity (e.g. docker rm cpud_test)
+docker run --rm -v $KEY.pub,target=/key.pub -v $KEY,target=/key -v /tmp:/tmp --name cpud_test --privileged=true -t -i -p 17010:17010 ghcr.io/u-root/cpu:main
 ```
 
 Then you can try running a command or two:
 ```
-docker exec -it  cpud_test  /bin/cpu -key /key localhost /bin/date
+docker exec -it -e PWD=/ cpud_test  /bin/cpu -key /key localhost /bin/date
 ```
 
 Remember, this cpu command is running in the container. You need to use the name /key in the
@@ -131,7 +119,7 @@ container, not $KEY.
 
 To see the mounts:
 ```
-docker exec -it  cpud_test  /bin/cpu -key /key localhost /bin/cat /proc/mounts
+docker exec -it -e PWD=/ cpud_test  /bin/cpu -key /key localhost /bin/cat /proc/mounts
 ```
 
 You might want to just get a cpu command to let you talk to the docker cpud

--- a/README.md
+++ b/README.md
@@ -106,20 +106,25 @@ storing keys in the container itself.
 docker network create cpud
 # If you ran docker before and it failed in some way, you may need to remove the
 # old identity (e.g. docker rm cpud_test)
-docker run --rm -v $KEY.pub,target=/key.pub -v $KEY,target=/key -v /tmp:/tmp --name cpud_test --privileged=true -t -i -p 17010:17010 ghcr.io/u-root/cpu:main
+docker run --rm -v $KEY.pub:/key.pub -v $KEY:/key -v /tmp --name cpud_test --privileged=true -t -i -p 17010:17010 ghcr.io/u-root/cpu:main
 ```
 
-Then you can try running a command or two:
+Then you can try running a command or two by using the embedded cpu client in the docker container.  
+_NOTE_: when you run cpu in this way, it does not immediately have access to your host's file system, 
+which means you won't be able to really leverage the back-mount and you'll have to artificially set 
+environment variables (like PWD) so that the remote task can execute.
+
 ```
-docker exec -it -e PWD=/ cpud_test  /bin/cpu -key /key localhost /bin/date
+docker exec -it -e PWD=/root cpud_test  /bin/cpu -key /key localhost /bin/date
 ```
 
 Remember, this cpu command is running in the container. You need to use the name /key in the
-container, not $KEY.
+container, not $KEY and you'll only be able to run binaries that have been pre-loaded into the 
+container (which in the public container is /bin/cat and /bin/date)
 
 To see the mounts:
 ```
-docker exec -it -e PWD=/ cpud_test  /bin/cpu -key /key localhost /bin/cat /proc/mounts
+docker exec -it -e PWD=/root cpud_test  /bin/cpu -key /key localhost /bin/cat /proc/mounts
 ```
 
 You might want to just get a cpu command to let you talk to the docker cpud
@@ -132,6 +137,15 @@ And now you can run
 ```
 cpu -key $KEY localhost date
 ```
+
+_NOTE_: if you are running on OSX, remember that your cpud docker is linux, so if you try the above
+command you'll see:
+```
+$ cpu -key $KEY localhost date
+2022/10/13 18:52:17 CPUD(as remote):fork/exec /bin/date: exec format error
+```
+
+To deal with that we'll have to play games with the namespace, which we'll cover next.
 
 ### cpu on heterogeneous systems.
 
@@ -156,6 +170,9 @@ Breaking this down, we set up the namespace so that:
 
 We can use the path /bin/bash, because /bin/bash on the remote points to `pwd`/bin/bash on the local
 machine.
+
+We can use the same trick to cpu to Linux from OSX, but instead of having an Arm tree under `pwd`
+we'll need a Linux binary tree to pick binaries from.
 
 ## cpu will be familiar to ssh users
 


### PR DESCRIPTION
Point people are the ghcr.io container which is now automatically
populated by gitlab CI.  The container version is pegged to the branch
at the moment so its cpu:main, I wasn't sure how you wanted to handle
release flow of u-root/cpu:latest, probably best for now to create a
custom action that is only triggerable by an owner to tag whatever is in
cpu:main to cpu:latest.  Once we've done that we can update docs again.

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>