### PR TITLE
cpu.go: Make sure c.Close() is called on all paths

### DIFF
--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -131,6 +131,7 @@ func newCPU(host string, args ...string) error {
 	client.V = v
 	// note that 9P is enabled if namespace is not empty OR if ninep is true
 	c := client.Command(host, args...)
+	defer c.Close()
 	if err := c.SetOptions(
 		client.WithPrivateKeyFile(*keyFile),
 		client.WithHostKeyFile(*hostKeyFile),
@@ -154,12 +155,14 @@ func newCPU(host string, args ...string) error {
 	}
 	v("CPU:wait")
 	if err := c.Wait(); err != nil {
-		log.Printf("Wait: %v", err)
+		return fmt.Errorf("Wait: %v", err)
 	}
 	v("CPU:close")
-	err := c.Close()
+	if err := c.Close(); err != nil {
+		return fmt.Errorf("Close: %v", err)
+	}
 	v("CPU:close done")
-	return err
+	return nil
 }
 
 func usage() {


### PR DESCRIPTION
Currently if c.Dial() or c.Start() fails, the closers are not called. Also, if c.Wait() fails, the corresponding error is dropped and not returned back to caller. As a result, in most cases, if a command failed on the remote server, the cpu process still exits with 0.

This PR makes sure c.Close() is called on all paths and the error is returned to the caller. It also makes sure closers are called in a last-in-first-called order.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>