### PR TITLE
client.go: Set std in/out/err like exec.Cmd

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -56,9 +56,12 @@ type Cmd struct {
 	Port           string
 	Timeout        time.Duration
 	Env            []string
-	Stdin          io.WriteCloser
-	Stdout         io.Reader
-	Stderr         io.Reader
+	SessionIn      io.WriteCloser
+	SessionOut     io.Reader
+	SessionErr     io.Reader
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
 	Row            int
 	Col            int
 	hasTTY         bool // Set if we have a TTY
@@ -122,6 +125,9 @@ func Command(host string, args ...string) *Cmd {
 		Args:     args,
 		Port:     DefaultPort,
 		Timeout:  defaultTimeOut,
+		Stdin:    os.Stdin,
+		Stdout:   os.Stdout,
+		Stderr:   os.Stderr,
 		Row:      row,
 		Col:      col,
 		config: ssh.ClientConfig{
@@ -425,18 +431,18 @@ func (c *Cmd) Start() error {
 	if err := c.SetEnv(c.Env...); err != nil {
 		return err
 	}
-	if c.Stdin, err = c.session.StdinPipe(); err != nil {
+	if c.SessionIn, err = c.session.StdinPipe(); err != nil {
 		return err
 	}
 	c.closers = append([]func() error{func() error {
-		c.Stdin.Close()
+		c.SessionIn.Close()
 		return nil
 	}}, c.closers...)
 
-	if c.Stdout, err = c.session.StdoutPipe(); err != nil {
+	if c.SessionOut, err = c.session.StdoutPipe(); err != nil {
 		return err
 	}
-	if c.Stderr, err = c.session.StderrPipe(); err != nil {
+	if c.SessionErr, err = c.session.StderrPipe(); err != nil {
 		return err
 	}
 
@@ -481,24 +487,24 @@ func (c *Cmd) Start() error {
 		if err := c.SetupInteractive(); err != nil {
 			return err
 		}
-		go c.TTYIn(c.session, c.Stdin, os.Stdin)
+		go c.TTYIn(c.session, c.SessionIn, c.Stdin)
 	} else {
 		go func() {
-			if _, err := io.Copy(c.Stdin, os.Stdin); err != nil && !errors.Is(err, io.EOF) {
+			if _, err := io.Copy(c.SessionIn, c.Stdin); err != nil && !errors.Is(err, io.EOF) {
 				log.Printf("copying stdin: %v", err)
 			}
-			if err := c.Stdin.Close(); err != nil {
+			if err := c.SessionIn.Close(); err != nil {
 				log.Printf("Closing stdin: %v", err)
 			}
 		}()
 	}
 	go func() {
-		if _, err := io.Copy(os.Stdout, c.Stdout); err != nil && !errors.Is(err, io.EOF) {
+		if _, err := io.Copy(c.Stdout, c.SessionOut); err != nil && !errors.Is(err, io.EOF) {
 			log.Printf("copying stdout: %v", err)
 		}
 	}()
 	go func() {
-		if _, err := io.Copy(os.Stderr, c.Stderr); err != nil && !errors.Is(err, io.EOF) {
+		if _, err := io.Copy(c.Stderr, c.SessionErr); err != nil && !errors.Is(err, io.EOF) {
 			log.Printf("copying stderr: %v", err)
 		}
 	}()

--- a/client/cpu_test.go
+++ b/client/cpu_test.go
@@ -176,7 +176,7 @@ func TestDialRun(t *testing.T) {
 	if err = c.Start(); err != nil {
 		t.Fatalf("Start: got %v, want nil", err)
 	}
-	if err := c.Stdin.Close(); err != nil {
+	if err := c.SessionIn.Close(); err != nil {
 		t.Errorf("Close stdin: Got %v, want nil", err)
 	}
 	if err := c.Wait(); err != nil {
@@ -218,7 +218,7 @@ func TestSetupInteractive(t *testing.T) {
 	if err = c.Start(); err != nil {
 		t.Fatalf("Start: got %v, want nil", err)
 	}
-	if err := c.Stdin.Close(); err != nil {
+	if err := c.SessionIn.Close(); err != nil {
 		t.Errorf("Close stdin: Got %v, want nil", err)
 	}
 	if err := c.Wait(); err != nil {

--- a/client/fns.go
+++ b/client/fns.go
@@ -241,10 +241,10 @@ func (c *Cmd) Signal(s ssh.Signal) error {
 func (c *Cmd) Outputs() ([]bytes.Buffer, error) {
 	var r [2]bytes.Buffer
 	var errs []error
-	if _, err := io.Copy(&r[0], c.Stdout); err != nil && err != io.EOF {
+	if _, err := io.Copy(&r[0], c.SessionOut); err != nil && err != io.EOF {
 		errs = append(errs, fmt.Errorf("Stdout: %w", err))
 	}
-	if _, err := io.Copy(&r[1], c.Stderr); err != nil && err != io.EOF {
+	if _, err := io.Copy(&r[1], c.SessionErr); err != nil && err != io.EOF {
 		errs = append(errs, fmt.Errorf("Stderr: %w", err))
 	}
 	if errs != nil {

--- a/server/server_linux_test.go
+++ b/server/server_linux_test.go
@@ -148,7 +148,7 @@ func TestDaemonSession(t *testing.T) {
 			t.Fatalf("Close: got %v, want nil", err)
 		}
 	}()
-	if err := c.Stdin.Close(); err != nil && !errors.Is(err, io.EOF) {
+	if err := c.SessionIn.Close(); err != nil && !errors.Is(err, io.EOF) {
 		t.Errorf("Close stdin: Got %v, want nil", err)
 	}
 	if err := c.Wait(); err != nil {
@@ -237,7 +237,7 @@ func TestDaemonConnect(t *testing.T) {
 			t.Fatalf("Close: got %v, want nil", err)
 		}
 	}()
-	if err := c.Stdin.Close(); err != nil && !errors.Is(err, io.EOF) {
+	if err := c.SessionIn.Close(); err != nil && !errors.Is(err, io.EOF) {
 		t.Errorf("Close stdin: Got %v, want nil", err)
 	}
 	if err := c.Wait(); err != nil {


### PR DESCRIPTION
The Stdin/Stdout/Stderr fields of exec.Cmd represents the file descriptors that the cmd can use as its stdin/stdout. So Stdin of exec.Cmd is an io.Reader and Stdout/Stderr are io.Writer.

On the other hand, the current Stdin/Stdout/Stderr fields of client.Cmd have different meanings: they are actually the pipes for fetching data from or writing data to the SSH session, so Stdin is a writer and stdout/stderr are readers.

This PR renames the original Stdin/Stdout/Stderr to SessionIn/SessionOut/SessionErr and adds new Stdin/Stdout/Stderr fields similar to exec.Cmd.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>