### PR TITLE
client: escape command arguments

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alessio/shellescape"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mdlayher/vsock"
 	"github.com/u-root/u-root/pkg/termios"
@@ -462,21 +463,8 @@ func (c *Cmd) Start() error {
 	// as needed, claiming to do proper unquote handling.
 	// This means we have to take care about quotes on
 	// our side.
-	//
-	// Be careful here: you want to use
-	// %v, not %q. %q will quote the string, and when
-	// ssh server unpacks it, this will look like one arg.
-	// This will manifest as weird problems when you
-	// cpu host ls -l and such. The ls -l will end up being
-	// a single arg. Why does this happen on cpu and not ssh?
-	// cpu, unlike ssh, does not pass the arguments to a shell.
-	// Unlike Plan 9 shells, Linux shells do gargantuan amounts
-	// of file IO for each command, and it's a very noticeable
-	// performance hit.
-	// TODO:
-	// Possibly the correct thing here is to loop over
-	// c.Args and print each argument as %q.
-	cmd += fmt.Sprintf(" %v", strings.Join(c.Args, " "))
+
+	cmd += " " + shellescape.QuoteCommand(c.Args)
 
 	V("call session.Start(%s)", cmd)
 	if err := c.session.Start(cmd); err != nil {

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -176,21 +176,23 @@ func main() {
 		usage()
 	}
 	host := args[0]
-	a := strings.Join(args[1:], " ")
-	verbose("Running as client, to host %q, args %q", host, a)
+	a := args[1:]
 	if len(a) == 0 {
-		a = os.Getenv("SHELL")
-		if len(a) == 0 {
-			a = "/bin/sh"
+		shellEnv := os.Getenv("SHELL")
+		if len(shellEnv) > 0 {
+			a = []string{shellEnv}
+		} else {
+			a = []string{"/bin/sh"}
 		}
 	}
+	verbose("Running as client, to host %q, args %q", host, a)
 
 	*keyFile = getKeyFile(host, *keyFile)
 	*port = getPort(host, *port)
 	hn := getHostName(host)
 
 	v("Running package-based cpu command")
-	if err := newCPU(hn, a); err != nil {
+	if err := newCPU(hn, a...); err != nil {
 		e := 1
 		log.Printf("SSH error %s", err)
 		sshErr := &ossh.ExitError{}

--- a/cmds/decpu/decpu.go
+++ b/cmds/decpu/decpu.go
@@ -176,10 +176,10 @@ func main() {
 	flags()
 	args := flag.Args()
 	host := ds.DsDefault
-	a := ""
+	a := []string{}
 	if len(args) > 0 {
 		host = args[0]
-		a = strings.Join(args[1:], " ")
+		a = args[1:]
 	}
 	if host == "." {
 		host = ds.DsDefault
@@ -198,9 +198,11 @@ func main() {
 
 	verbose("Running as client, to host %q, args %q", host, a)
 	if len(a) == 0 {
-		a = os.Getenv("SHELL")
-		if len(a) == 0 {
-			a = "/bin/sh"
+		shellEnv := os.Getenv("SHELL")
+		if len(shellEnv) > 0 {
+			a = []string{shellEnv}
+		} else {
+			a = []string{"/bin/sh"}
 		}
 	}
 
@@ -209,7 +211,7 @@ func main() {
 	hn := getHostName(host)
 
 	v("Running package-based cpu command")
-	if err := newCPU(hn, a); err != nil {
+	if err := newCPU(hn, a...); err != nil {
 		e := 1
 		log.Printf("SSH error %s", err)
 		sshErr := &ossh.ExitError{}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 )
 
 require (
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/brutella/dnssd v1.2.4 h1:hmSHQnUS5qujI8PX1QKHDhmwzZVvd63YINFfF9jcGfE=


### PR DESCRIPTION
Currently, If we run
  `./cpu <host-name> ./binary --arg1 "value with space"`
The client wiil actually run the following command on the remote host
  `./binary --arg1 value with space`
where `arg1=value` and the binary gets two extra arguments `with` and `space`, because the quote is lost.

This PR imports the shellescape package. With the fix, the remote host will receive a correctly quoted command line:
  `./binary --arg1 'value with space'`