### PR TITLE
Fix verbose priting

### DIFF
--- a/client/cpu9p.go
+++ b/client/cpu9p.go
@@ -82,26 +82,26 @@ func (l *cpu9p) Walk(names []string) ([]p9.QID, p9.File, error) {
 	if len(names) == 0 {
 		c := &cpu9p{path: last.path}
 		qid, fi, err := c.info()
-		V("Walk to %v: %v, %v, %v", *c, qid, fi, err)
+		verbose("Walk to %v: %v, %v, %v", *c, qid, fi, err)
 		if err != nil {
 			return nil, nil, err
 		}
 		qids = append(qids, qid)
-		V("Walk: return %v, %v, nil", qids, last)
+		verbose("Walk: return %v, %v, nil", qids, last)
 		return qids, last, nil
 	}
-	V("Walk: %v", names)
+	verbose("Walk: %v", names)
 	for _, name := range names {
 		c := &cpu9p{path: filepath.Join(last.path, name)}
 		qid, fi, err := c.info()
-		V("Walk to %v: %v, %v, %v", *c, qid, fi, err)
+		verbose("Walk to %v: %v, %v, %v", *c, qid, fi, err)
 		if err != nil {
 			return nil, nil, err
 		}
 		qids = append(qids, qid)
 		last = c
 	}
-	V("Walk: return %v, %v, nil", qids, last)
+	verbose("Walk: return %v, %v, nil", qids, last)
 	return qids, last, nil
 }
 

--- a/client/cpu9p_unix.go
+++ b/client/cpu9p_unix.go
@@ -59,7 +59,7 @@ func (l *cpu9p) SetAttr(mask p9.SetAttrMask, attr p9.SetAttr) error {
 	if mask.CTime {
 		// The Linux client sets CTime. I did not even know that was allowed.
 		// if e := errors.New("Can not set CTime on Unix"); e != nil { err = multierror.Append(e)}
-		V("mask.CTime is set by client; ignoring")
+		verbose("mask.CTime is set by client; ignoring")
 	}
 	if mask.Permissions {
 		if e := unix.Chmod(l.path, uint32(attr.Permissions)); e != nil {

--- a/client/cpu_test.go
+++ b/client/cpu_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	V = t.Logf
+	v = t.Logf
 	var tconfig = `
 Host *.example.com
   Compression yes
@@ -162,7 +162,7 @@ func TestDialRun(t *testing.T) {
 	if err != nil {
 		t.Skipf("%v", err)
 	}
-	V = t.Logf
+	v = t.Logf
 	// From this test forward, at least try to get a port.
 	// For this test, there must be a key.
 
@@ -204,7 +204,7 @@ func TestSetupInteractive(t *testing.T) {
 	if err != nil {
 		t.Skipf("%v", err)
 	}
-	V = t.Logf
+	v = t.Logf
 	// From this test forward, at least try to get a port.
 	// For this test, there must be a key.
 

--- a/client/fns.go
+++ b/client/fns.go
@@ -44,7 +44,7 @@ var (
 type nonce [32]byte
 
 func verbose(f string, a ...interface{}) {
-	V("\r\n"+f+"\r\n", a...)
+	v("CPU:client:"+f+"\r\n", a...)
 }
 
 // generateNonce returns a nonce, or an error if random reader fails.
@@ -69,7 +69,7 @@ func (c *Cmd) UserKeyConfig() error {
 	kf := c.PrivateKeyFile
 	if len(kf) == 0 {
 		kf = config.Get(c.Host, "IdentityFile")
-		V("key file from config is %q", kf)
+		verbose("key file from config is %q", kf)
 		if len(kf) == 0 {
 			kf = DefaultKeyFile
 		}
@@ -169,10 +169,10 @@ func (c *Cmd) SSHStdin(w io.WriteCloser, r io.Reader) {
 // GetKeyFile picks a keyfile if none has been set.
 // It will use ssh config, else use a default.
 func GetKeyFile(host, kf string) string {
-	V("getKeyFile for %q", kf)
+	verbose("getKeyFile for %q", kf)
 	if len(kf) == 0 {
 		kf = config.Get(host, "IdentityFile")
-		V("key file from config is %q", kf)
+		verbose("key file from config is %q", kf)
 		if len(kf) == 0 {
 			kf = DefaultKeyFile
 		}
@@ -181,7 +181,7 @@ func GetKeyFile(host, kf string) string {
 	if strings.HasPrefix(kf, "~") {
 		kf = filepath.Join(os.Getenv("HOME"), kf[1:])
 	}
-	V("getKeyFile returns %q", kf)
+	verbose("getKeyFile returns %q", kf)
 	// this is a tad annoying, but the config package doesn't handle ~.
 	return kf
 }
@@ -202,18 +202,18 @@ func GetHostName(host string) string {
 // of "22", convert to defaultPort.
 func GetPort(host, port string) (string, error) {
 	p := port
-	V("getPort(%q, %q)", host, port)
+	verbose("getPort(%q, %q)", host, port)
 	if len(port) == 0 {
 		if cp := config.Get(host, "Port"); len(cp) != 0 {
-			V("config.Get(%q,%q): %q", host, port, cp)
+			verbose("config.Get(%q,%q): %q", host, port, cp)
 			p = cp
 		}
 	}
 	if len(p) == 0 || p == "22" {
 		p = DefaultPort
-		V("getPort: return default %q", p)
+		verbose("getPort: return default %q", p)
 	}
-	V("returns %q", p)
+	verbose("returns %q", p)
 	return p, nil
 }
 

--- a/client/srv.go
+++ b/client/srv.go
@@ -24,20 +24,20 @@ func (c *Cmd) srv(l net.Listener) error {
 		err  error
 	)
 	go func() {
-		V("srv: try to accept l %v", l)
+		verbose("srv: try to accept l %v", l)
 		s, err = l.Accept()
-		V("Accept: %v %v", s, err)
+		verbose("Accept: %v %v", s, err)
 		if err != nil {
 			errs <- fmt.Errorf("accept 9p socket: %v", err)
 			return
 		}
-		V("srv got %v", s)
+		verbose("srv got %v", s)
 		var rn nonce
 		if _, err := io.ReadAtLeast(s, rn[:], len(rn)); err != nil {
 			errs <- fmt.Errorf("Reading nonce from remote: %v", err)
 			return
 		}
-		V("srv: read the nonce back got %s", rn)
+		verbose("srv: read the nonce back got %s", rn)
 		if c.nonce.String() != rn.String() {
 			errs <- fmt.Errorf("nonce mismatch: got %s but want %s", rn, c.nonce)
 			return
@@ -56,7 +56,7 @@ func (c *Cmd) srv(l net.Listener) error {
 		return fmt.Errorf("srv: %v", err)
 	}
 	// If we are debugging, add the option to trace records.
-	V("Start serving on %v", c.Root)
+	verbose("Start serving on %v", c.Root)
 	if Debug9p {
 		if Dump9p {
 			log.SetOutput(DumpWriter)

--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -21,19 +21,25 @@ var (
 	pubKeyFile  = flag.String("pk", "key.pub", "file for public key")
 	port        = flag.String("sp", "17010", "cpu default port")
 
-	debug     = flag.Bool("d", true, "enable debug prints")
+	debug     = flag.Bool("d", false, "enable debug prints")
 	runAsInit = flag.Bool("init", false, "run as init (Debug only; normal test is if we are pid 1")
-	v         = func(string, ...interface{}) {}
-	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
-	network   = flag.String("net", "tcp", "network to use")
-	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
-	klog      = flag.Bool("klog", false, "Log cpud messages in kernel log, not stdout")
+	// v allows debug printing.
+	// Do not call it directly, call verbose instead.
+	v       = func(string, ...interface{}) {}
+	remote  = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
+	network = flag.String("net", "tcp", "network to use")
+	port9p  = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
+	klog    = flag.Bool("klog", false, "Log cpud messages in kernel log, not stdout")
 
 	pid1 bool
 )
 
 func verbose(f string, a ...interface{}) {
-	v("\r\nCPUD:"+f+"\r\n", a...)
+	if *remote {
+		v("CPUD(remote):"+f+"\r\n", a...)
+	} else {
+		v("CPUD:"+f, a...)
+	}
 }
 
 func main() {

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -68,7 +68,7 @@ func initsetup() error {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
 		verbose("Run %v", cmd)
 		if err := cmd.Start(); err != nil {
-			verbose("CPUD:Error starting %v: %v", v, err)
+			verbose("Error starting %v: %v", v, err)
 			continue
 		}
 	}
@@ -110,18 +110,18 @@ func serve() error {
 		log.Printf(`New(%q, %q): %v`, *pubKeyFile, *hostKeyFile, err)
 		hang()
 	}
-	v("Server is %v", s)
+	verbose("Server is %v", s)
 
 	ln, err := listen(*network, *port)
 	if err != nil {
 		return err
 	}
-	v("Listening on %v", ln.Addr())
+	log.Printf("CPUD:Listening on %v", ln.Addr())
 	if err := s.Serve(ln); err != ssh.ErrServerClosed {
 		log.Printf("s.Daemon(): %v != %v", err, ssh.ErrServerClosed)
 		hang()
 	}
-	v("Daemon returns")
+	verbose("Daemon returns")
 	hang()
 	return nil
 }

--- a/cmds/decpu/decpu.go
+++ b/cmds/decpu/decpu.go
@@ -46,13 +46,14 @@ var (
 	timeout9P   = flag.String("timeout9p", "100ms", "time to wait for the 9p mount to happen.")
 	ninep       = flag.Bool("9p", true, "Enable the 9p mount in the client")
 	tmpMnt      = flag.String("tmpMnt", "/tmp", "Mount point of the private namespace.")
-
+	// v allows debug printing.
+	// Do not call it directly, call verbose instead.
 	v          = func(string, ...interface{}) {}
 	dumpWriter *os.File
 )
 
 func verbose(f string, a ...interface{}) {
-	v("\r\n"+f+"\r\n", a...)
+	v("DECPU:"+f+"\r\n", a...)
 }
 
 func flags() {
@@ -80,10 +81,10 @@ func flags() {
 // getKeyFile picks a keyfile if none has been set.
 // It will use sshconfig, else use a default.
 func getKeyFile(host, kf string) string {
-	v("getKeyFile for %q", kf)
+	verbose("getKeyFile for %q", kf)
 	if len(kf) == 0 {
 		kf = config.Get(host, "IdentityFile")
-		v("key file from config is %q", kf)
+		verbose("key file from config is %q", kf)
 		if len(kf) == 0 {
 			kf = defaultKeyFile
 		}
@@ -92,7 +93,7 @@ func getKeyFile(host, kf string) string {
 	if strings.HasPrefix(kf, "~") {
 		kf = filepath.Join(os.Getenv("HOME"), kf[1:])
 	}
-	v("getKeyFile returns %q", kf)
+	verbose("getKeyFile returns %q", kf)
 	// this is a tad annoying, but the config package doesn't handle ~.
 	return kf
 }
@@ -113,18 +114,18 @@ func getHostName(host string) string {
 // of "22", convert to defaultPort
 func getPort(host, port string) string {
 	p := port
-	v("getPort(%q, %q)", host, port)
+	verbose("getPort(%q, %q)", host, port)
 	if len(port) == 0 {
 		if cp := config.Get(host, "Port"); len(cp) != 0 {
-			v("config.Get(%q,%q): %q", host, port, cp)
+			verbose("config.Get(%q,%q): %q", host, port, cp)
 			p = cp
 		}
 	}
 	if len(p) == 0 || p == "22" {
 		p = defaultPort
-		v("getPort: return default %q", p)
+		verbose("getPort: return default %q", p)
 	}
-	v("returns %q", p)
+	verbose("returns %q", p)
 	return p
 }
 
@@ -138,7 +139,6 @@ func usage() {
 }
 
 func newCPU(host string, args ...string) error {
-	client.V = v
 	// note that 9P is enabled if namespace is not empty OR if ninep is true
 	c := client.Command(host, args...)
 	if err := c.SetOptions(
@@ -158,17 +158,17 @@ func newCPU(host string, args ...string) error {
 	if err := c.Dial(); err != nil {
 		return fmt.Errorf("Dial: %v", err)
 	}
-	v("CPU:start")
+	verbose("CPU:start")
 	if err := c.Start(); err != nil {
 		return fmt.Errorf("Start: %v", err)
 	}
-	v("CPU:wait")
+	verbose("CPU:wait")
 	if err := c.Wait(); err != nil {
-		log.Printf("Wait: %v", err)
+		log.Printf("Wait: %v\r\n", err)
 	}
-	v("CPU:close")
+	verbose("CPU:close")
 	err := c.Close()
-	v("CPU:close done")
+	verbose("CPU:close done")
 	return err
 }
 
@@ -192,7 +192,7 @@ func main() {
 			host = sdHost
 			*port = sdPort
 		} else {
-			v("ds.Lookup returned %w", err)
+			verbose("ds.Lookup returned %w", err)
 		}
 	}
 
@@ -210,7 +210,7 @@ func main() {
 	*port = getPort(host, *port)
 	hn := getHostName(host)
 
-	v("Running package-based cpu command")
+	verbose("Running package-based cpu command")
 	if err := newCPU(hn, a...); err != nil {
 		e := 1
 		log.Printf("SSH error %s", err)

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -35,7 +35,7 @@ func init() {
 	// might magically exist, b/c of initrd; or be automagically mounted via
 	// some other mechanism.
 	if os.Getpid() == 1 {
-		v("PID 1")
+		verbose("PID 1")
 	}
 }
 

--- a/server/server_linux_test.go
+++ b/server/server_linux_test.go
@@ -132,7 +132,7 @@ func TestDaemonSession(t *testing.T) {
 	}
 
 	t.Logf("HostName %q, IdentityFile %q, command %v", host, kf, os.Args[0])
-	client.V = t.Logf
+	client.SetVerbose(t.Logf)
 	c := client.Command(host, os.Args[0], "-remote", "ls", "-l")
 	if err := c.SetOptions(client.WithPrivateKeyFile(kf), client.WithPort(port), client.WithRoot(d), client.WithNameSpace(d)); err != nil {
 		t.Fatalf("SetOptions: %v != nil", err)

--- a/server/server_other.go
+++ b/server/server_other.go
@@ -24,20 +24,20 @@ func (s *Session) Namespace() (error, error) {
 	// N.B. We do not save the nonce in the cpu struct.
 	nonce := os.Getenv("CPUNONCE")
 	os.Unsetenv("CPUNONCE")
-	v("CPUD:namespace is %q", s.binds)
+	verbose("namespace is %q", s.binds)
 
 	// Connect to the socket, return the nonce.
 	a := net.JoinHostPort("localhost", s.port9p)
-	v("CPUD:Dial %v", a)
+	verbose("Dial %v", a)
 	so, err := net.Dial("tcp", a)
 	if err != nil {
 		return warning, fmt.Errorf("CPUD:Dial 9p port: %v", err)
 	}
-	v("CPUD:Connected: write nonce %s\n", nonce)
+	verbose("Connected: write nonce %s\n", nonce)
 	if _, err := fmt.Fprintf(so, "%s", nonce); err != nil {
 		return warning, fmt.Errorf("CPUD:Write nonce: %v", err)
 	}
-	v("CPUD:Wrote the nonce")
+	verbose("Wrote the nonce")
 	// Zero it. I realize I am not a crypto person.
 	// improvements welcome.
 	copy([]byte(nonce), make([]byte, len(nonce)))

--- a/session/fns.go
+++ b/session/fns.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+func verbose(f string, a ...interface{}) {
+	v("CPUD(remote):session:"+f+"\r\n", a...)
+}
+
 // ParseBinds parses a CPU_NAMESPACE-style string to a
 // slice of Bind structures.
 func ParseBinds(s string) ([]Bind, error) {

--- a/session/session_other.go
+++ b/session/session_other.go
@@ -23,20 +23,20 @@ func (s *Session) Namespace() (error, error) {
 	// N.B. We do not save the nonce in the cpu struct.
 	nonce := os.Getenv("CPUNONCE")
 	os.Unsetenv("CPUNONCE")
-	v("CPUD:namespace is %q", s.binds)
+	verbose("namespace is %q", s.binds)
 
 	// Connect to the socket, return the nonce.
 	a := net.JoinHostPort("localhost", s.port9p)
-	v("CPUD:Dial %v", a)
+	verbose("Dial %v", a)
 	so, err := net.Dial("tcp", a)
 	if err != nil {
 		return warning, fmt.Errorf("CPUD:Dial 9p port: %v", err)
 	}
-	v("CPUD:Connected: write nonce %s\n", nonce)
+	verbose("Connected: write nonce %s\n", nonce)
 	if _, err := fmt.Fprintf(so, "%s", nonce); err != nil {
 		return warning, fmt.Errorf("CPUD:Write nonce: %v", err)
 	}
-	v("CPUD:Wrote the nonce")
+	verbose("Wrote the nonce")
 	// Zero it. I realize I am not a crypto person.
 	// improvements welcome.
 	copy([]byte(nonce), make([]byte, len(nonce)))


### PR DESCRIPTION
This PR fix the usage of verbose() and v(). v() will be the log function provided by the user and verbose() is used in the package. v() is not called directly besides verbose().

We need to consider 3 kinds of verbose printings:
1. printings from cpud ssh server
2. printings from cpud remote mode
3. printings from local cpu command

The 1st will be logged to server, so we do not need to care about terminal interface. For the 2nd and 3rd cases, logs will be printed or forwarded to local terminal window. Since local terminal will also be used as the ssh terminal window, we need to add the extra `\r\n` to the end of log messages.

Function v() of package session was never set when cpud is running in remote mode.

This PR sets up the v() function of package session at the beginning of CPUD process.

source file in `cmds/decpud` and `ds` are not changed yet. 

