### PR TITLE
cpud: add a switch to 'register' cpud with a remote host

### DIFF
--- a/cmds/cpud/cpuddoc.go
+++ b/cmds/cpud/cpuddoc.go
@@ -5,28 +5,30 @@
 // cpud -- cpu daemon
 //
 // Synopsis:
-//     cpu [OPTIONS]
+//
+//	cpu [OPTIONS]
 //
 // Advisory:
 //
 // Options:
-//     -d    enable debug prints
-//     -dbg9p
-//           show 9p io
-//     -hostkey string
-//           host key file
-//     -key string
-//           key file (default "$HOME/.ssh/cpu_rsa")
-//     -network string
-//           network to use (default "tcp")
-//     -p string
-//           port to use (default "17010")
-//     -port9p string
-//           port9p # on remote machine for 9p mount
-//     -remote
-//           Indicates we are the remote side of the cpu session
-//     -srv string
-//           what server to run (default none; use internal)
+//
+//	-d    enable debug prints
+//	-dbg9p
+//	      show 9p io
+//	-hostkey string
+//	      host key file
+//	-key string
+//	      key file (default "$HOME/.ssh/cpu_rsa")
+//	-network string
+//	      network to use (default "tcp")
+//	-p string
+//	      port to use (default "17010")
+//	-port9p string
+//	      port9p # on remote machine for 9p mount
+//	-remote
+//	      Indicates we are the remote side of the cpu session
+//	-srv string
+//	      what server to run (default none; use internal)
 //
 // cpud is the daemon side of a cpu session.
 // In the original Plan 9 implementation, cpu was a command that contained

--- a/cmds/cpud/cpuddoc.go
+++ b/cmds/cpud/cpuddoc.go
@@ -30,6 +30,14 @@
 //	-srv string
 //	      what server to run (default none; use internal)
 //
+//      For registering with a controller
+//      -register netaddr
+//            netaddr in Go style (host:port) to Dial and send 'ok' to
+//
+//      -registerTO
+//            timeout in time.Duration format (e.g. 25s, 1m, etc.)
+//            for connection to succeed.
+//
 // cpud is the daemon side of a cpu session.
 // In the original Plan 9 implementation, cpu was a command that contained
 // both server and client sides of a cpu session. The server side was started

--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"time"
 
 	// We use this ssh because it implements port redirection.
 	// It can not, however, unpack password-protected keys yet.
@@ -28,6 +29,10 @@ var (
 	network   = flag.String("net", "tcp", "network to use")
 	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
 	klog      = flag.Bool("klog", false, "Log cpud messages in kernel log, not stdout")
+
+	// Some networks are not well behaved, and for them we implement registration.
+	registerAddr = flag.String("register", "", "address and port to register with after listen on cpu server port")
+	registerTO   = flag.Duration("registerTO", time.Duration(5*time.Second), "time.Duration for Dial address for registering")
 
 	pid1 bool
 )

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"net"
@@ -104,6 +105,29 @@ func listen(network, port string) (net.Listener, error) {
 	return ln, err
 }
 
+func register(network, addr string, timeout time.Duration) error {
+	if len(addr) == 0 {
+		return nil
+	}
+	// This is a bit of a hack for now, to test the idea.
+	// if registeraddr is not empty, Dial it over the network,
+	// and send the string "ok".
+	// This may fail because the host may have incorrectly requested a registration
+	// but may not be listening, OR may just be looking for a cheap way to set a
+	// delay between listen and accept for networks that are not well behaved.
+	c, err := net.DialTimeout(network, addr, timeout)
+	// N.B.: it fails to connect, it fails to connect.
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	// if it works, it works. It not, log it and move on.
+	if _, err := c.Write([]byte("ok")); err != nil {
+		return fmt.Errorf("Writing OK to register address: %w", err)
+	}
+	return nil
+}
+
 func serve() error {
 	s, err := server.New(*pubKeyFile, *hostKeyFile)
 	if err != nil {
@@ -117,6 +141,12 @@ func serve() error {
 		return err
 	}
 	v("Listening on %v", ln.Addr())
+
+	// register can return an error, but it should not block serving.
+	if err := register(*network, *registerAddr, *registerTO); err != nil {
+		v("Register(%v, %v, %d): %v", *network, *registerAddr, *registerTO, err)
+	}
+
 	if err := s.Serve(ln); err != ssh.ErrServerClosed {
 		log.Printf("s.Daemon(): %v != %v", err, ssh.ErrServerClosed)
 		hang()

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -121,7 +121,7 @@ func register(network, addr string, timeout time.Duration) error {
 		return err
 	}
 	defer c.Close()
-	// if it works, it works. It not, log it and move on.
+	// if it works, it works. If not, log it and move on.
 	if _, err := c.Write([]byte("ok")); err != nil {
 		return fmt.Errorf("Writing OK to register address: %w", err)
 	}


### PR DESCRIPTION
In VMs and IoT, it is useful to have some idea that a host has come up. Pinging the cpud port until cpud comes up does not work well, especially in systems using vsock. What is most desired is that cpud 'check in', or register, with a control host so that the contol host can keep track of which cpuds are up and working.

Once the cpud has registered, the control host can periodically run a command to ensure the host is still up.

This PR adds a flag (default off) which tells cpud to register, what address to use, and a second flag to tell cpud how long to wait for the register to succeed.

The register flag is a Go-style addr (host:port) which specifies a host to connect to once cpud has called Listen and before it calls Serve. cpud will use the network on which it listens. Assuming the connect succeeds, cpud will send the two-byte string 'ok' to indicate its status.

registerTO specifies the timeout in seconds for the connect.

Currently, a failure to register or write 'ok' does not block cpud from continuing on to accept connections. Further, cpud will only print an error message if debug is enabled.

This PR includes a test for the new function.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>