### PR TITLE
Fix support for specifying dnssd instance

### DIFF
--- a/ds/ds.go
+++ b/ds/ds.go
@@ -125,17 +125,21 @@ func Parse(uri string) (dsQuery, error) {
 		return result, fmt.Errorf("Not an dns-sd URI")
 	}
 
-	// following dns-sd URI conventions from CUPS dnssd://instance._type._proto.domain/?query
-	if u.Hostname() != "" {
+	// following dns-sd URI conventions from CUPS
+	//   (e.g. dnssd://instance._type._proto.domain/?query)
+	//   We are going to look for the _type._proto tuple and split the
+	//   components around it because domain could have more than one
+	//   . speperated coponent (it could be local or example.com)
+	if len(u.Hostname()) != 0 {
 		parts := strings.Split(u.Hostname(), ".")
 		found := false
 		for p, v := range parts {
-			if v[0] == '_' {
+			if strings.HasPrefix(v, "_") {
 				if p > 0 {
 					result.Instance = strings.Join(parts[0:p], ".")
 				}
 				if len(parts) > p+1 {
-					if parts[p+1][0] == '_' {
+					if strings.HasPrefix(parts[p+1], "_") {
 						result.Type = parts[p] + "." + parts[p+1]
 					}
 					p = p + 2

--- a/ds/ds.go
+++ b/ds/ds.go
@@ -126,10 +126,10 @@ func Parse(uri string) (dsQuery, error) {
 	}
 
 	// following dns-sd URI conventions from CUPS
-	//   (e.g. dnssd://instance._type._proto.domain/?query)
-	//   We are going to look for the _type._proto tuple and split the
-	//   components around it because domain could have more than one
-	//   . speperated coponent (it could be local or example.com)
+	// (e.g. dnssd://instance._type._proto.domain/?query)
+	// We are going to look for the _type._proto tuple and split the
+	// components around it because domain could have more than one
+	// . speperated coponent (it could be local or example.com)
 	if len(u.Hostname()) != 0 {
 		parts := strings.Split(u.Hostname(), ".")
 		found := false

--- a/ds/ds_test.go
+++ b/ds/ds_test.go
@@ -10,6 +10,63 @@ import (
 	"time"
 )
 
+type testURI struct {
+	uri    string
+	result dsQuery
+}
+
+// test parsing logic
+func TestParse(t *testing.T) {
+	v = t.Logf
+
+	var tus = []struct {
+		uri    string
+		result dsQuery
+		error  bool
+	}{
+		{"bad", dsQuery{}, true},
+		{"dnssd://", dsQuery{Type: "_ncpu._tcp", Domain: "local"}, false},
+		{"dnssd://local", dsQuery{Type: "_ncpu._tcp", Domain: "local"}, false},
+		{"dnssd://localhost", dsQuery{Type: "_ncpu._tcp", Domain: "localhost"}, false},
+		{"dnssd://example.com", dsQuery{Type: "_ncpu._tcp", Domain: "example.com"}, false},
+		{"dnssd://_ncpu._tcp", dsQuery{Type: "_ncpu._tcp", Domain: "local"}, false},
+		{"dnssd://_nobody._tcp", dsQuery{Type: "_nobody._tcp", Domain: "local"}, false},
+		{"dnssd://_nobody", dsQuery{Type: "_nobody", Domain: "local"}, false}, // malformed
+		{"dnssd://instance._ncpu._tcp", dsQuery{Instance: "instance", Type: "_ncpu._tcp", Domain: "local"}, false},
+		{"dnssd://instance._ncpu._tcp.example.com", dsQuery{Instance: "instance", Type: "_ncpu._tcp", Domain: "example.com"}, false},
+	}
+
+	for _, x := range tus {
+		d, error := Parse(x.uri)
+		r := x.result
+		if x.error {
+			if error == nil {
+				t.Fatal(fmt.Errorf("failed to detect error parsing %s", x.uri))
+			}
+			continue
+		} else {
+			if error != nil {
+				t.Fatal(fmt.Errorf("failed to parse URI %s", x.uri))
+			}
+		}
+		if len(r.Type) != 0 {
+			if r.Type != d.Type {
+				t.Fatal(fmt.Errorf("parsing %s resulted bad Type parsing %s!=%s", x.uri, r.Type, d.Type))
+			}
+		}
+		if len(r.Domain) != 0 {
+			if r.Domain != d.Domain {
+				t.Fatal(fmt.Errorf("parsing %s resulted bad Domain parsing %s!=%s", x.uri, r.Domain, d.Type))
+			}
+		}
+		if len(r.Instance) != 0 {
+			if r.Instance != d.Instance {
+				t.Fatal(fmt.Errorf("parsing %s resulted bad Instance parsing %s!=%s", x.uri, r.Instance, d.Type))
+			}
+		}
+	}
+}
+
 func TestClient(t *testing.T) {
 	v = t.Logf
 


### PR DESCRIPTION
cpu dnssd URI didn't support specifying an instance. Augment parsing and lookup code to allow for specifying specific instance by passing full qualified dnssd path.

Bug originally reported by @rminnich 

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>