### PR TITLE
session: fix verbose logs

### DIFF
--- a/session/fns.go
+++ b/session/fns.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+func verbose(f string, a ...interface{}) {
+	v("session:"+f, a...)
+}
+
 // ParseBinds parses a CPU_NAMESPACE-style string to a
 // slice of Bind structures.
 func ParseBinds(s string) ([]Bind, error) {

--- a/session/session_other.go
+++ b/session/session_other.go
@@ -23,20 +23,20 @@ func (s *Session) Namespace() (error, error) {
 	// N.B. We do not save the nonce in the cpu struct.
 	nonce := os.Getenv("CPUNONCE")
 	os.Unsetenv("CPUNONCE")
-	v("CPUD:namespace is %q", s.binds)
+	verbose("namespace is %q", s.binds)
 
 	// Connect to the socket, return the nonce.
 	a := net.JoinHostPort("localhost", s.port9p)
-	v("CPUD:Dial %v", a)
+	verbose("Dial %v", a)
 	so, err := net.Dial("tcp", a)
 	if err != nil {
 		return warning, fmt.Errorf("CPUD:Dial 9p port: %v", err)
 	}
-	v("CPUD:Connected: write nonce %s\n", nonce)
+	verbose("Connected: write nonce %s\n", nonce)
 	if _, err := fmt.Fprintf(so, "%s", nonce); err != nil {
 		return warning, fmt.Errorf("CPUD:Write nonce: %v", err)
 	}
-	v("CPUD:Wrote the nonce")
+	verbose("Wrote the nonce")
 	// Zero it. I realize I am not a crypto person.
 	// improvements welcome.
 	copy([]byte(nonce), make([]byte, len(nonce)))


### PR DESCRIPTION
Fix the verbose logs of package session. Use `verbose` instead of `v` everywhere. `v` refers to the log function provided by users and `verbose` calls `v` and adds an appropriate prefix.

Add function SetVerbose() such that users of package session can set the log function.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>