### PR TITLE
client: fix verbose logs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -35,8 +35,9 @@ const (
 	DefaultNameSpace = "/lib:/lib64:/usr:/bin:/etc:/home"
 )
 
-// V allows debug printing.
-var V = func(string, ...interface{}) {}
+// v allows debug printing.
+// Do not call it directly, call verbose instead.
+var v = func(string, ...interface{}) {}
 
 // Cmd is a cpu client.
 // It implements as much of exec.Command as makes sense.
@@ -95,7 +96,7 @@ func (c *Cmd) SetOptions(opts ...Set) error {
 // SetVerbose sets the verbose printing function.
 // e.g., one might call SetVerbose(log.Printf)
 func SetVerbose(f func(string, ...interface{})) {
-	V = f
+	v = f
 }
 
 // Command implements exec.Command. The required parameter is a host.
@@ -283,13 +284,13 @@ func WithPort(port string) Set {
 // It's a shame vsock is not in the net package (yet ... or ever?)
 func vsockDial(host, port string) (net.Conn, string, error) {
 	id, portid, err := vsockIDPort(host, port)
-	V("vsock(%v, %v) = %v, %v, %v", host, port, id, portid, err)
+	verbose("vsock(%v, %v) = %v, %v, %v", host, port, id, portid, err)
 	if err != nil {
 		return nil, "", err
 	}
 	addr := fmt.Sprintf("%#x:%d", id, portid)
 	conn, err := vsock.Dial(id, portid, nil)
-	V("vsock id %#x port %d addr %#x conn %v err %v", id, port, addr, conn, err)
+	verbose("vsock id %#x port %s addr %#x conn %v err %v", id, port, addr, conn, err)
 	return conn, addr, err
 
 }
@@ -302,11 +303,11 @@ func unixVsockDial(path, port string) (net.Conn, string, error) {
 	}
 	connectMsg := []byte(fmt.Sprintf("CONNECT %s\n", port))
 	if n, err := conn.Write(connectMsg); err != nil || n != len(connectMsg) {
-		V("send connect request err, number of sent bytes = %d: %v", n, err)
+		verbose("send connect request err, number of sent bytes = %d: %v", n, err)
 	}
 	s := bufio.NewScanner(conn)
 	if !s.Scan() || !strings.HasPrefix(s.Text(), "OK") {
-		V("connect request failed.")
+		verbose("connect request failed.")
 	}
 	return conn, path, nil
 }
@@ -346,7 +347,7 @@ func (c *Cmd) Dial() error {
 		addr = net.JoinHostPort(c.HostName, c.Port)
 		conn, err = net.Dial(c.network, addr)
 	}
-	V("connect: err %v", err)
+	verbose("connect: err %v", err)
 	if err != nil {
 		return err
 	}
@@ -355,7 +356,7 @@ func (c *Cmd) Dial() error {
 		return err
 	}
 	cl := ssh.NewClient(sshconn, chans, reqs)
-	V("cpu:ssh.Dial(%s, %s, %v): (%v, %v)", c.network, addr, c.config, cl, err)
+	verbose("cpu:ssh.Dial(%s, %s, %v): (%v, %v)", c.network, addr, c.config, cl, err)
 	if err != nil {
 		return fmt.Errorf("Failed to dial: %v", err)
 	}
@@ -382,7 +383,7 @@ func (c *Cmd) Dial() error {
 				return fmt.Errorf("cpu client listen for forwarded 9p port %v", err)
 			}
 		}
-		V("ssh.listener %v", l.Addr().String())
+		verbose("ssh.listener %v", l.Addr().String())
 		ap := strings.Split(l.Addr().String(), ":")
 		if len(ap) == 0 {
 			return fmt.Errorf("Can't find a port number in %v", l.Addr().String())
@@ -393,7 +394,7 @@ func (c *Cmd) Dial() error {
 		}
 		c.port9p = uint16(port9p)
 
-		V("listener %T %v addr %v port %v", l, l, l.Addr().String(), port9p)
+		verbose("listener %T %v addr %v port %v", l, l, l.Addr().String(), port9p)
 
 		nonce, err := generateNonce()
 		if err != nil {
@@ -401,9 +402,9 @@ func (c *Cmd) Dial() error {
 		}
 		c.nonce = nonce
 		c.Env = append(c.Env, "CPUNONCE="+nonce.String())
-		V("Set NONCE to %q", nonce.String())
+		verbose("Set NONCE to %q", nonce.String())
 		c.Env = append(c.Env, "CPU_TMPMNT="+c.TmpMnt)
-		V("Set CPU_TMPMNT to %q", "CPU_TMPMNT="+c.TmpMnt)
+		verbose("Set CPU_TMPMNT to %q", "CPU_TMPMNT="+c.TmpMnt)
 		go func(l net.Listener) {
 			if err := c.srv(l); err != nil {
 				log.Printf("9p server error: %v", err)
@@ -439,7 +440,7 @@ func (c *Cmd) Start() error {
 
 	// Request pseudo terminal
 	if c.hasTTY {
-		V("c.session.RequestPty(\"ansi\", %v, %v, %#x", c.Row, c.Col, modes)
+		verbose("c.session.RequestPty(\"ansi\", %v, %v, %#x", c.Row, c.Col, modes)
 		if err := c.session.RequestPty("ansi", c.Row, c.Col, modes); err != nil {
 			return fmt.Errorf("request for pseudo terminal failed: %v", err)
 		}
@@ -492,12 +493,12 @@ func (c *Cmd) Start() error {
 	}
 	cmd += " " + strings.Join(quotedArgs, " ")
 
-	V("call session.Start(%s)", cmd)
+	verbose("call session.Start(%s)", cmd)
 	if err := c.session.Start(cmd); err != nil {
 		return fmt.Errorf("Failed to run %v: %v", c, err.Error())
 	}
 	if c.hasTTY {
-		V("Setup interactive input")
+		verbose("Setup interactive input")
 		if err := c.SetupInteractive(); err != nil {
 			return err
 		}

--- a/client/cpu9p.go
+++ b/client/cpu9p.go
@@ -82,26 +82,26 @@ func (l *cpu9p) Walk(names []string) ([]p9.QID, p9.File, error) {
 	if len(names) == 0 {
 		c := &cpu9p{path: last.path}
 		qid, fi, err := c.info()
-		V("Walk to %v: %v, %v, %v", *c, qid, fi, err)
+		verbose("Walk to %v: %v, %v, %v", *c, qid, fi, err)
 		if err != nil {
 			return nil, nil, err
 		}
 		qids = append(qids, qid)
-		V("Walk: return %v, %v, nil", qids, last)
+		verbose("Walk: return %v, %v, nil", qids, last)
 		return qids, last, nil
 	}
-	V("Walk: %v", names)
+	verbose("Walk: %v", names)
 	for _, name := range names {
 		c := &cpu9p{path: filepath.Join(last.path, name)}
 		qid, fi, err := c.info()
-		V("Walk to %v: %v, %v, %v", *c, qid, fi, err)
+		verbose("Walk to %v: %v, %v, %v", *c, qid, fi, err)
 		if err != nil {
 			return nil, nil, err
 		}
 		qids = append(qids, qid)
 		last = c
 	}
-	V("Walk: return %v, %v, nil", qids, last)
+	verbose("Walk: return %v, %v, nil", qids, last)
 	return qids, last, nil
 }
 

--- a/client/cpu9p_unix.go
+++ b/client/cpu9p_unix.go
@@ -59,7 +59,7 @@ func (l *cpu9p) SetAttr(mask p9.SetAttrMask, attr p9.SetAttr) error {
 	if mask.CTime {
 		// The Linux client sets CTime. I did not even know that was allowed.
 		// if e := errors.New("Can not set CTime on Unix"); e != nil { err = multierror.Append(e)}
-		V("mask.CTime is set by client; ignoring")
+		verbose("mask.CTime is set by client; ignoring")
 	}
 	if mask.Permissions {
 		if e := unix.Chmod(l.path, uint32(attr.Permissions)); e != nil {

--- a/client/cpu_test.go
+++ b/client/cpu_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	V = t.Logf
+	v = t.Logf
 	var tconfig = `
 Host *.example.com
   Compression yes
@@ -162,7 +162,7 @@ func TestDialRun(t *testing.T) {
 	if err != nil {
 		t.Skipf("%v", err)
 	}
-	V = t.Logf
+	v = t.Logf
 	// From this test forward, at least try to get a port.
 	// For this test, there must be a key.
 
@@ -204,7 +204,7 @@ func TestSetupInteractive(t *testing.T) {
 	if err != nil {
 		t.Skipf("%v", err)
 	}
-	V = t.Logf
+	v = t.Logf
 	// From this test forward, at least try to get a port.
 	// For this test, there must be a key.
 

--- a/client/fns.go
+++ b/client/fns.go
@@ -44,7 +44,7 @@ var (
 type nonce [32]byte
 
 func verbose(f string, a ...interface{}) {
-	V("\r\n"+f+"\r\n", a...)
+	v("client:"+f, a...)
 }
 
 // generateNonce returns a nonce, or an error if random reader fails.
@@ -69,7 +69,7 @@ func (c *Cmd) UserKeyConfig() error {
 	kf := c.PrivateKeyFile
 	if len(kf) == 0 {
 		kf = config.Get(c.Host, "IdentityFile")
-		V("key file from config is %q", kf)
+		verbose("key file from config is %q", kf)
 		if len(kf) == 0 {
 			kf = DefaultKeyFile
 		}
@@ -169,10 +169,10 @@ func (c *Cmd) SSHStdin(w io.WriteCloser, r io.Reader) {
 // GetKeyFile picks a keyfile if none has been set.
 // It will use ssh config, else use a default.
 func GetKeyFile(host, kf string) string {
-	V("getKeyFile for %q", kf)
+	verbose("getKeyFile for %q", kf)
 	if len(kf) == 0 {
 		kf = config.Get(host, "IdentityFile")
-		V("key file from config is %q", kf)
+		verbose("key file from config is %q", kf)
 		if len(kf) == 0 {
 			kf = DefaultKeyFile
 		}
@@ -181,7 +181,7 @@ func GetKeyFile(host, kf string) string {
 	if strings.HasPrefix(kf, "~") {
 		kf = filepath.Join(os.Getenv("HOME"), kf[1:])
 	}
-	V("getKeyFile returns %q", kf)
+	verbose("getKeyFile returns %q", kf)
 	// this is a tad annoying, but the config package doesn't handle ~.
 	return kf
 }
@@ -202,18 +202,18 @@ func GetHostName(host string) string {
 // of "22", convert to defaultPort.
 func GetPort(host, port string) (string, error) {
 	p := port
-	V("getPort(%q, %q)", host, port)
+	verbose("getPort(%q, %q)", host, port)
 	if len(port) == 0 {
 		if cp := config.Get(host, "Port"); len(cp) != 0 {
-			V("config.Get(%q,%q): %q", host, port, cp)
+			verbose("config.Get(%q,%q): %q", host, port, cp)
 			p = cp
 		}
 	}
 	if len(p) == 0 || p == "22" {
 		p = DefaultPort
-		V("getPort: return default %q", p)
+		verbose("getPort: return default %q", p)
 	}
-	V("returns %q", p)
+	verbose("returns %q", p)
 	return p, nil
 }
 

--- a/client/srv.go
+++ b/client/srv.go
@@ -24,20 +24,20 @@ func (c *Cmd) srv(l net.Listener) error {
 		err  error
 	)
 	go func() {
-		V("srv: try to accept l %v", l)
+		verbose("srv: try to accept l %v", l)
 		s, err = l.Accept()
-		V("Accept: %v %v", s, err)
+		verbose("Accept: %v %v", s, err)
 		if err != nil {
 			errs <- fmt.Errorf("accept 9p socket: %v", err)
 			return
 		}
-		V("srv got %v", s)
+		verbose("srv got %v", s)
 		var rn nonce
 		if _, err := io.ReadAtLeast(s, rn[:], len(rn)); err != nil {
 			errs <- fmt.Errorf("Reading nonce from remote: %v", err)
 			return
 		}
-		V("srv: read the nonce back got %s", rn)
+		verbose("srv: read the nonce back got %s", rn)
 		if c.nonce.String() != rn.String() {
 			errs <- fmt.Errorf("nonce mismatch: got %s but want %s", rn, c.nonce)
 			return
@@ -56,7 +56,7 @@ func (c *Cmd) srv(l net.Listener) error {
 		return fmt.Errorf("srv: %v", err)
 	}
 	// If we are debugging, add the option to trace records.
-	V("Start serving on %v", c.Root)
+	verbose("Start serving on %v", c.Root)
 	if Debug9p {
 		if Dump9p {
 			log.SetOutput(DumpWriter)

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -46,12 +46,14 @@ var (
 	ninep       = flag.Bool("9p", true, "Enable the 9p mount in the client")
 	tmpMnt      = flag.String("tmpMnt", "/tmp", "Mount point of the private namespace.")
 
+	// v allows debug printing.
+	// Do not call it directly, call verbose instead.
 	v          = func(string, ...interface{}) {}
 	dumpWriter *os.File
 )
 
 func verbose(f string, a ...interface{}) {
-	v("\r\n"+f+"\r\n", a...)
+	v("CPU:"+f+"\r\n", a...)
 }
 
 func flags() {
@@ -61,7 +63,7 @@ func flags() {
 	}
 	if *debug {
 		v = log.Printf
-		client.SetVerbose(log.Printf)
+		client.SetVerbose(verbose)
 	}
 	if *dump {
 		var err error
@@ -79,10 +81,10 @@ func flags() {
 // getKeyFile picks a keyfile if none has been set.
 // It will use sshconfig, else use a default.
 func getKeyFile(host, kf string) string {
-	v("getKeyFile for %q", kf)
+	verbose("getKeyFile for %q", kf)
 	if len(kf) == 0 {
 		kf = config.Get(host, "IdentityFile")
-		v("key file from config is %q", kf)
+		verbose("key file from config is %q", kf)
 		if len(kf) == 0 {
 			kf = defaultKeyFile
 		}
@@ -91,7 +93,7 @@ func getKeyFile(host, kf string) string {
 	if strings.HasPrefix(kf, "~") {
 		kf = filepath.Join(os.Getenv("HOME"), kf[1:])
 	}
-	v("getKeyFile returns %q", kf)
+	verbose("getKeyFile returns %q", kf)
 	// this is a tad annoying, but the config package doesn't handle ~.
 	return kf
 }
@@ -112,23 +114,22 @@ func getHostName(host string) string {
 // of "22", convert to defaultPort
 func getPort(host, port string) string {
 	p := port
-	v("getPort(%q, %q)", host, port)
+	verbose("getPort(%q, %q)", host, port)
 	if len(port) == 0 {
 		if cp := config.Get(host, "Port"); len(cp) != 0 {
-			v("config.Get(%q,%q): %q", host, port, cp)
+			verbose("config.Get(%q,%q): %q", host, port, cp)
 			p = cp
 		}
 	}
 	if len(p) == 0 || p == "22" {
 		p = defaultPort
-		v("getPort: return default %q", p)
+		verbose("getPort: return default %q", p)
 	}
-	v("returns %q", p)
+	verbose("returns %q", p)
 	return p
 }
 
 func newCPU(host string, args ...string) error {
-	client.V = v
 	// note that 9P is enabled if namespace is not empty OR if ninep is true
 	c := client.Command(host, args...)
 	if err := c.SetOptions(
@@ -148,17 +149,17 @@ func newCPU(host string, args ...string) error {
 	if err := c.Dial(); err != nil {
 		return fmt.Errorf("Dial: %v", err)
 	}
-	v("CPU:start")
+	verbose("start")
 	if err := c.Start(); err != nil {
 		return fmt.Errorf("Start: %v", err)
 	}
-	v("CPU:wait")
+	verbose("wait")
 	if err := c.Wait(); err != nil {
-		log.Printf("Wait: %v", err)
+		log.Printf("Wait: %v\r\n", err)
 	}
-	v("CPU:close")
+	verbose("close")
 	err := c.Close()
-	v("CPU:close done")
+	verbose("close done")
 	return err
 }
 
@@ -191,7 +192,7 @@ func main() {
 	*port = getPort(host, *port)
 	hn := getHostName(host)
 
-	v("Running package-based cpu command")
+	verbose("Running package-based cpu command")
 	if err := newCPU(hn, a...); err != nil {
 		e := 1
 		log.Printf("SSH error %s", err)

--- a/cmds/decpu/decpu.go
+++ b/cmds/decpu/decpu.go
@@ -46,13 +46,14 @@ var (
 	timeout9P   = flag.String("timeout9p", "100ms", "time to wait for the 9p mount to happen.")
 	ninep       = flag.Bool("9p", true, "Enable the 9p mount in the client")
 	tmpMnt      = flag.String("tmpMnt", "/tmp", "Mount point of the private namespace.")
-
+	// v allows debug printing.
+	// Do not call it directly, call verbose instead.
 	v          = func(string, ...interface{}) {}
 	dumpWriter *os.File
 )
 
 func verbose(f string, a ...interface{}) {
-	v("\r\n"+f+"\r\n", a...)
+	v("DECPU:"+f+"\r\n", a...)
 }
 
 func flags() {
@@ -62,7 +63,8 @@ func flags() {
 	}
 	if *debug {
 		v = log.Printf
-		ds.Verbose(log.Printf)
+		client.SetVerbose(verbose)
+		ds.Verbose(verbose)
 	}
 	if *dump {
 		var err error
@@ -80,10 +82,10 @@ func flags() {
 // getKeyFile picks a keyfile if none has been set.
 // It will use sshconfig, else use a default.
 func getKeyFile(host, kf string) string {
-	v("getKeyFile for %q", kf)
+	verbose("getKeyFile for %q", kf)
 	if len(kf) == 0 {
 		kf = config.Get(host, "IdentityFile")
-		v("key file from config is %q", kf)
+		verbose("key file from config is %q", kf)
 		if len(kf) == 0 {
 			kf = defaultKeyFile
 		}
@@ -92,7 +94,7 @@ func getKeyFile(host, kf string) string {
 	if strings.HasPrefix(kf, "~") {
 		kf = filepath.Join(os.Getenv("HOME"), kf[1:])
 	}
-	v("getKeyFile returns %q", kf)
+	verbose("getKeyFile returns %q", kf)
 	// this is a tad annoying, but the config package doesn't handle ~.
 	return kf
 }
@@ -113,18 +115,18 @@ func getHostName(host string) string {
 // of "22", convert to defaultPort
 func getPort(host, port string) string {
 	p := port
-	v("getPort(%q, %q)", host, port)
+	verbose("getPort(%q, %q)", host, port)
 	if len(port) == 0 {
 		if cp := config.Get(host, "Port"); len(cp) != 0 {
-			v("config.Get(%q,%q): %q", host, port, cp)
+			verbose("config.Get(%q,%q): %q", host, port, cp)
 			p = cp
 		}
 	}
 	if len(p) == 0 || p == "22" {
 		p = defaultPort
-		v("getPort: return default %q", p)
+		verbose("getPort: return default %q", p)
 	}
-	v("returns %q", p)
+	verbose("returns %q", p)
 	return p
 }
 
@@ -138,7 +140,6 @@ func usage() {
 }
 
 func newCPU(host string, args ...string) error {
-	client.V = v
 	// note that 9P is enabled if namespace is not empty OR if ninep is true
 	c := client.Command(host, args...)
 	if err := c.SetOptions(
@@ -158,17 +159,17 @@ func newCPU(host string, args ...string) error {
 	if err := c.Dial(); err != nil {
 		return fmt.Errorf("Dial: %v", err)
 	}
-	v("CPU:start")
+	verbose("CPU:start")
 	if err := c.Start(); err != nil {
 		return fmt.Errorf("Start: %v", err)
 	}
-	v("CPU:wait")
+	verbose("CPU:wait")
 	if err := c.Wait(); err != nil {
 		log.Printf("Wait: %v", err)
 	}
-	v("CPU:close")
+	verbose("CPU:close")
 	err := c.Close()
-	v("CPU:close done")
+	verbose("CPU:close done")
 	return err
 }
 
@@ -192,7 +193,7 @@ func main() {
 			host = sdHost
 			*port = sdPort
 		} else {
-			v("ds.Lookup returned %w", err)
+			verbose("ds.Lookup returned %w", err)
 		}
 	}
 
@@ -210,7 +211,7 @@ func main() {
 	*port = getPort(host, *port)
 	hn := getHostName(host)
 
-	v("Running package-based cpu command")
+	verbose("Running package-based cpu command")
 	if err := newCPU(hn, a...); err != nil {
 		e := 1
 		log.Printf("SSH error %s", err)

--- a/server/server_linux_test.go
+++ b/server/server_linux_test.go
@@ -132,7 +132,7 @@ func TestDaemonSession(t *testing.T) {
 	}
 
 	t.Logf("HostName %q, IdentityFile %q, command %v", host, kf, os.Args[0])
-	client.V = t.Logf
+	client.SetVerbose(t.Logf)
 	c := client.Command(host, os.Args[0], "-remote", "ls", "-l")
 	if err := c.SetOptions(client.WithPrivateKeyFile(kf), client.WithPort(port), client.WithRoot(d), client.WithNameSpace(d)); err != nil {
 		t.Fatalf("SetOptions: %v != nil", err)


### PR DESCRIPTION
Fix the verbose logs of package `client` and commands `cpu` and `decpu`.

Since we have function `SetVerbose` in `client/client.go`, `V` does not need to be exported.

Removed `client.V = v` from `newCPU` in `cpu.go` and `decpu.go` since function `flags()` has already called
`client.SetVerbose(log.Printf)`.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>