### PR TITLE
fix verbose logs in cpud

### DIFF
--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -22,13 +22,15 @@ var (
 	pubKeyFile  = flag.String("pk", "key.pub", "file for public key")
 	port        = flag.String("sp", "17010", "cpu default port")
 
-	debug     = flag.Bool("d", true, "enable debug prints")
+	debug     = flag.Bool("d", false, "enable debug prints")
 	runAsInit = flag.Bool("init", false, "run as init (Debug only; normal test is if we are pid 1")
-	v         = func(string, ...interface{}) {}
-	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
-	network   = flag.String("net", "tcp", "network to use")
-	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
-	klog      = flag.Bool("klog", false, "Log cpud messages in kernel log, not stdout")
+	// v allows debug printing.
+	// Do not call it directly, call verbose instead.
+	v       = func(string, ...interface{}) {}
+	remote  = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
+	network = flag.String("net", "tcp", "network to use")
+	port9p  = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
+	klog    = flag.Bool("klog", false, "Log cpud messages in kernel log, not stdout")
 
 	// Some networks are not well behaved, and for them we implement registration.
 	registerAddr = flag.String("register", "", "address and port to register with after listen on cpu server port")
@@ -38,27 +40,30 @@ var (
 )
 
 func verbose(f string, a ...interface{}) {
-	v("\r\nCPUD:"+f+"\r\n", a...)
+	if *remote {
+		v("CPUD(remote):"+f+"\r\n", a...)
+	} else {
+		v("CPUD:"+f, a...)
+	}
 }
 
 func main() {
 	flag.Parse()
+	if *remote {
+		if *debug {
+			v = log.Printf
+			session.SetVerbose(verbose)
+		}
+	} else {
+		if err := commonsetup(); err != nil {
+			log.Fatal(err)
+		}
+	}
 	pid1 = os.Getpid() == 1
 	*runAsInit = *runAsInit || pid1
 	verbose("Args %v pid %d *runasinit %v *remote %v env %v", os.Args, os.Getpid(), *runAsInit, *remote, os.Environ())
 	args := flag.Args()
-	switch {
-	case *runAsInit:
-		if err := commonsetup(); err != nil {
-			log.Fatal(err)
-		}
-		if err := initsetup(); err != nil {
-			log.Fatal(err)
-		}
-		if err := serve(); err != nil {
-			log.Fatal(err)
-		}
-	case *remote:
+	if *remote {
 		verbose("server package: Running as remote: args %q, port9p %v", args, *port9p)
 		tmpMnt, ok := os.LookupEnv("CPU_TMPMNT")
 		if !ok || len(tmpMnt) == 0 {
@@ -68,10 +73,12 @@ func main() {
 		if err := s.Run(); err != nil {
 			log.Fatalf("CPUD(as remote):%v", err)
 		}
-	default:
-		log.Printf("cpud: running as a server (a.k.a. starter of cpud's for sessions")
-		if err := commonsetup(); err != nil {
-			log.Fatal(err)
+	} else {
+		log.Printf("CPUD:running as a server (a.k.a. starter of cpud's for sessions)")
+		if *runAsInit {
+			if err := initsetup(); err != nil {
+				log.Fatal(err)
+			}
 		}
 		if err := serve(); err != nil {
 			log.Fatal(err)

--- a/cmds/cpud/main.go
+++ b/cmds/cpud/main.go
@@ -64,14 +64,14 @@ func main() {
 	verbose("Args %v pid %d *runasinit %v *remote %v env %v", os.Args, os.Getpid(), *runAsInit, *remote, os.Environ())
 	args := flag.Args()
 	if *remote {
-		verbose("server package: Running as remote: args %q, port9p %v", args, *port9p)
+		log.Printf("CPUD(remote): args %q, port9p %v", args, *port9p)
 		tmpMnt, ok := os.LookupEnv("CPU_TMPMNT")
 		if !ok || len(tmpMnt) == 0 {
 			tmpMnt = "/tmp"
 		}
 		s := session.New(*port9p, tmpMnt, args[0], args[1:]...)
 		if err := s.Run(); err != nil {
-			log.Fatalf("CPUD(as remote):%v", err)
+			log.Fatalf("CPUD(remote): %v", err)
 		}
 	} else {
 		log.Printf("CPUD:running as a server (a.k.a. starter of cpud's for sessions)")

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -37,7 +37,7 @@ func hang() {
 
 func commonsetup() error {
 	if *debug {
-		server.SetVerbose(log.Printf)
+		server.SetVerbose(verbose)
 		v = log.Printf
 		if *klog {
 			ulog.KernelLog.Reinit()
@@ -69,7 +69,7 @@ func initsetup() error {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
 		verbose("Run %v", cmd)
 		if err := cmd.Start(); err != nil {
-			verbose("CPUD:Error starting %v: %v", v, err)
+			verbose("Error starting %v: %v", v, err)
 			continue
 		}
 	}
@@ -134,24 +134,25 @@ func serve() error {
 		log.Printf(`New(%q, %q): %v`, *pubKeyFile, *hostKeyFile, err)
 		hang()
 	}
-	v("Server is %v", s)
+	verbose("Server is %v", s)
 
 	ln, err := listen(*network, *port)
 	if err != nil {
 		return err
 	}
-	v("Listening on %v", ln.Addr())
+
+	log.Printf("Listening on %v", ln.Addr())
 
 	// register can return an error, but it should not block serving.
 	if err := register(*network, *registerAddr, *registerTO); err != nil {
-		v("Register(%v, %v, %d): %v", *network, *registerAddr, *registerTO, err)
+		verbose("Register(%v, %v, %d): %v", *network, *registerAddr, *registerTO, err)
 	}
 
 	if err := s.Serve(ln); err != ssh.ErrServerClosed {
 		log.Printf("s.Daemon(): %v != %v", err, ssh.ErrServerClosed)
 		hang()
 	}
-	v("Daemon returns")
+	verbose("Daemon returns")
 	hang()
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -25,6 +25,8 @@ const (
 )
 
 var (
+	// v allows debug printing.
+	// Do not call it directly, call verbose instead.
 	v = func(string, ...interface{}) {}
 )
 
@@ -35,7 +37,7 @@ func SetVerbose(f func(string, ...interface{})) {
 }
 
 func verbose(f string, a ...interface{}) {
-	v("\r\nCPUD:"+f+"\r\n", a...)
+	v("server:"+f, a...)
 }
 
 func setWinsize(f *os.File, w, h int) {
@@ -58,16 +60,16 @@ func errval(err error) error {
 
 func handler(s ssh.Session) {
 	a := s.Command()
-	v("handler: cmd is %q", a)
+	verbose("handler: cmd is %q", a)
 	cmd := command(a[0], a[1:]...)
 	cmd.Env = append(cmd.Env, s.Environ()...)
 	ptyReq, winCh, isPty := s.Pty()
 	if isPty {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", ptyReq.Term))
 		f, err := pty.Start(cmd)
-		v("command started with pty")
+		verbose("command started with pty")
 		if err != nil {
-			v("CPUD:err %v", err)
+			verbose("err %v", err)
 			return
 		}
 		go func() {
@@ -92,19 +94,19 @@ func handler(s ssh.Session) {
 		// competing with each other and the results are odd to say the least.
 		// If the command exits, leaving orphans behind, it is the job
 		// of the reaper to get them.
-		v("wait for %q", cmd)
+		verbose("wait for %q", cmd)
 		err = cmd.Wait()
-		v("cmd %q returns with %v %v", cmd, err, cmd.ProcessState)
+		verbose("cmd %q returns with %v %v", cmd, err, cmd.ProcessState)
 		if errval(err) != nil {
-			v("CPUD:child exited with  %v", err)
+			verbose("child exited with  %v", err)
 			s.Exit(cmd.ProcessState.ExitCode()) //nolint
 		}
 
 	} else {
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = s, s, s
-		v("running command without pty")
+		verbose("running command without pty")
 		if err := cmd.Run(); errval(err) != nil {
-			v("CPUD:err %v", err)
+			verbose("err %v", err)
 			s.Exit(1) //nolint
 		}
 	}
@@ -114,7 +116,7 @@ func handler(s ssh.Session) {
 // New sets up a cpud. cpud is really just an SSH server with a special
 // handler and support for port forwarding for the 9p port.
 func New(publicKeyFile, hostKeyFile string) (*ssh.Server, error) {
-	v("configure SSH server")
+	verbose("configure SSH server")
 	publicKeyOption := func(ctx ssh.Context, key ssh.PublicKey) bool {
 		data, err := ioutil.ReadFile(publicKeyFile)
 		if err != nil {
@@ -142,7 +144,7 @@ func New(publicKeyFile, hostKeyFile string) (*ssh.Server, error) {
 		Addr:             ":" + defaultPort,
 		PublicKeyHandler: publicKeyOption,
 		ReversePortForwardingCallback: ssh.ReversePortForwardingCallback(func(ctx ssh.Context, host string, port uint32) bool {
-			v("CPUD:ReversePortForwardingCallback: attempt to bind %v %v granted", host, port)
+			verbose("ReversePortForwardingCallback: attempt to bind %v %v granted", host, port)
 			return true
 		}),
 		RequestHandlers: map[string]ssh.RequestHandler{

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -35,7 +35,7 @@ func init() {
 	// might magically exist, b/c of initrd; or be automagically mounted via
 	// some other mechanism.
 	if os.Getpid() == 1 {
-		v("PID 1")
+		verbose("PID 1")
 	}
 }
 

--- a/server/server_other.go
+++ b/server/server_other.go
@@ -24,20 +24,20 @@ func (s *Session) Namespace() (error, error) {
 	// N.B. We do not save the nonce in the cpu struct.
 	nonce := os.Getenv("CPUNONCE")
 	os.Unsetenv("CPUNONCE")
-	v("CPUD:namespace is %q", s.binds)
+	verbose("namespace is %q", s.binds)
 
 	// Connect to the socket, return the nonce.
 	a := net.JoinHostPort("localhost", s.port9p)
-	v("CPUD:Dial %v", a)
+	verbose("Dial %v", a)
 	so, err := net.Dial("tcp", a)
 	if err != nil {
 		return warning, fmt.Errorf("CPUD:Dial 9p port: %v", err)
 	}
-	v("CPUD:Connected: write nonce %s\n", nonce)
+	verbose("Connected: write nonce %s\n", nonce)
 	if _, err := fmt.Fprintf(so, "%s", nonce); err != nil {
 		return warning, fmt.Errorf("CPUD:Write nonce: %v", err)
 	}
-	v("CPUD:Wrote the nonce")
+	verbose("Wrote the nonce")
 	// Zero it. I realize I am not a crypto person.
 	// improvements welcome.
 	copy([]byte(nonce), make([]byte, len(nonce)))


### PR DESCRIPTION
Fix verbose logs in package `cpud` and `server`.

This PR also changed default value of `cpud`'s `debug` to false.