### PR TITLE
server.go: Redirect cmds' stderr to SSH stderr channel

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -103,7 +103,7 @@ func handler(s ssh.Session) {
 		}
 
 	} else {
-		cmd.Stdin, cmd.Stdout, cmd.Stderr = s, s, s
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = s, s, s.Stderr()
 		verbose("running command without pty")
 		if err := cmd.Run(); errval(err) != nil {
 			verbose("err %v", err)


### PR DESCRIPTION
When a command in the server side is not running with a tty, its stderr should be redirected to SSH stderr channel instead of stdout channel, otherwise in the client side, the command's stdout and stderr are mixed together.

Tested with a simple C program:
```c
int main() {
    printf("test out\n");
    fprintf(stderr, "test err\n");
    return 0;
}
```

Without this patch:
```
[9:43:08] desktop: ~/cpu/cmds/cpu fix-stderr *
➜ PWD=/ ./cpu -key ./cpu_rsa -net vsock 121896393 ./test 1>out.txt 2>err.txt 0<in.txt
[9:43:23] desktop: ~/cpu/cmds/cpu fix-stderr *
➜ cat err.txt
[9:43:24] desktop: ~/cpu/cmds/cpu fix-stderr *
➜ cat out.txt
test err
test out
```
We can see both `test err` and `test out` show up in `out.txt`, and `err.txt` is empty.

With this patch:
```
[9:43:26] desktop: ~/cpu/cmds/cpu fix-stderr *
➜ PWD=/ ./cpu -key ./cpu_rsa -net vsock 3378875551 ./test 1>out.txt 2>err.txt 0<in.txt
[9:44:08] desktop: ~/cpu/cmds/cpu fix-stderr *
➜ cat out.txt
test out
[9:44:10] desktop: ~/cpu/cmds/cpu fix-stderr *
➜ cat err.txt
test err
```
`test err` and `test out` show up in `err.txt` and `out.txt` respectively.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>