### PR TITLE
client: Always set the env var CPU_TMPMNT

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -403,8 +403,6 @@ func (c *Cmd) Dial() error {
 		c.nonce = nonce
 		c.Env = append(c.Env, "CPUNONCE="+nonce.String())
 		verbose("Set NONCE to %q", nonce.String())
-		c.Env = append(c.Env, "CPU_TMPMNT="+c.TmpMnt)
-		verbose("Set CPU_TMPMNT to %q", "CPU_TMPMNT="+c.TmpMnt)
 		go func(l net.Listener) {
 			if err := c.srv(l); err != nil {
 				log.Printf("9p server error: %v", err)
@@ -414,6 +412,9 @@ func (c *Cmd) Dial() error {
 	if len(c.FSTab) > 0 {
 		c.Env = append(c.Env, "CPU_FSTAB="+c.FSTab)
 	}
+
+	c.Env = append(c.Env, "CPU_TMPMNT="+c.TmpMnt)
+	verbose("Set CPU_TMPMNT to %q", "CPU_TMPMNT="+c.TmpMnt)
 
 	return nil
 }


### PR DESCRIPTION
Without this patch, the `-tmpMnt` switch of cpu does not work if we are using fstab instead of the 9p server, i.e., the server still creates the tmpfs mount at /tmp instead of the one specified by users.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>