### PR TITLE
Fix ds to return a slice of results

### DIFF
--- a/cmds/decpu/decpu.go
+++ b/cmds/decpu/decpu.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	// We use this ssh because it implements port redirection.
@@ -174,6 +175,8 @@ func newCPU(host string, args ...string) error {
 }
 
 func main() {
+	var c []*ds.LookupResult
+
 	flags()
 	args := flag.Args()
 	host := ds.DsDefault
@@ -188,12 +191,12 @@ func main() {
 	dq, err := ds.Parse(host)
 
 	if err == nil {
-		sdHost, sdPort, err := ds.Lookup(dq)
-		if err == nil {
-			host = sdHost
-			*port = sdPort
+		c, err = ds.Lookup(dq, 1)
+		if err != nil {
+			verbose("ds.Lookup returned error %v", err)
 		} else {
-			verbose("ds.Lookup returned %w", err)
+			host = c[0].Entry.IPs[0].String()
+			*port = strconv.Itoa(c[0].Entry.Port)
 		}
 	}
 

--- a/ds/ds.go
+++ b/ds/ds.go
@@ -338,10 +338,6 @@ func Lookup(query dsQuery, n int) ([]*LookupResult, error) {
 		respCh <- nil
 	}()
 
-	if err != nil {
-		return nil, err
-	}
-
 	for {
 		e := <-respCh
 		if e == nil {
@@ -351,7 +347,7 @@ func Lookup(query dsQuery, n int) ([]*LookupResult, error) {
 	}
 
 	if len(responses) == 0 {
-		return nil, fmt.Errorf("dnssd found no suitable service")
+		return nil, fmt.Errorf("dnssd found no suitable service %w", err)
 	}
 
 	dsSort(query.Text, responses)

--- a/ds/ds_test.go
+++ b/ds/ds_test.go
@@ -72,7 +72,7 @@ func TestClient(t *testing.T) {
 	}
 
 	// simple lookup with no server and bad service, it better fail
-	if _, _, err := Lookup(q); err == nil {
+	if _, err := Lookup(q, 1); err == nil {
 		t.Fatalf("Lookup of bad service didn't fail: got nil, want an err")
 	}
 }
@@ -94,7 +94,7 @@ func TestDnsSdStart(t *testing.T) {
 	}
 
 	// simple lookup with no server and bad service, it better succeed
-	if _, _, err := Lookup(q); err != nil {
+	if _, err := Lookup(q, 1); err != nil {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
This patch changes Lookup to return a slice of up to n results, allowing the client to access more than one host based on sorted results from dns query.

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>