### PR TITLE
p9cpu: define a server trait and add a gRPC server struct

### DIFF
--- a/p9cpu/Cargo.lock
+++ b/p9cpu/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "prost-build",
  "thiserror",
  "tokio",
+ "tokio-vsock",
  "tonic",
  "tonic-build",
  "uuid",
@@ -545,6 +546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +577,18 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1024,6 +1046,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "tonic",
+ "vsock",
+]
+
+[[package]]
 name = "tonic"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1237,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
+dependencies = [
+ "libc",
+ "nix",
+]
 
 [[package]]
 name = "want"

--- a/p9cpu/crates/libp9cpu/Cargo.toml
+++ b/p9cpu/crates/libp9cpu/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.61"
 prost = "0.11.5"
 tonic = "0.8.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread","process","io-std", "fs", "io-util"] }
+tokio-vsock = { version = "0.4", features = ["tonic-conn"] }
 libc = "0.2.139"
 thiserror = "1"
 uuid = { version = "1", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/p9cpu/crates/libp9cpu/src/lib.rs
+++ b/p9cpu/crates/libp9cpu/src/lib.rs
@@ -1,10 +1,18 @@
 pub mod client;
+pub mod server;
 pub mod cmd;
 mod rpc;
 
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+#[derive(Debug)]
+pub enum Addr {
+    Tcp(std::net::SocketAddr),
+    Vsock(tokio_vsock::VsockAddr),
+    Uds(String),
+}
 
 pub(crate) struct TryOrErrInto<F> {
     future: F,

--- a/p9cpu/crates/libp9cpu/src/rpc/mod.rs
+++ b/p9cpu/crates/libp9cpu/src/rpc/mod.rs
@@ -1,4 +1,5 @@
-pub mod rpc_client;
+pub(crate) mod rpc_client;
+pub(crate) mod rpc_server;
 
 use futures::Stream;
 

--- a/p9cpu/crates/libp9cpu/src/rpc/rpc_server.rs
+++ b/p9cpu/crates/libp9cpu/src/rpc/rpc_server.rs
@@ -1,0 +1,84 @@
+use crate::rpc;
+use crate::Addr;
+use async_trait::async_trait;
+use futures::stream::Stream;
+use std::pin::Pin;
+use thiserror::Error;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status, Streaming};
+
+#[derive(Error, Debug)]
+pub enum RpcServerError {
+    #[error("RPC error: {0}")]
+    Transport(#[from] tonic::transport::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub struct RpcServer {}
+
+#[async_trait]
+impl crate::server::P9cpuServerT for RpcServer {
+    type Error = RpcServerError;
+    async fn serve(&self, addr: Addr) -> Result<(), RpcServerError> {
+        
+        let p9cpu_service = rpc::p9cpu_server::P9cpuServer::new(P9cpuService::default());
+        let router = Server::builder().add_service(p9cpu_service);
+        match addr {
+            Addr::Tcp(addr) => router.serve(addr).await?,
+            Addr::Uds(_addr) => {
+                unimplemented!()
+            }
+            Addr::Vsock(_addr) => {
+                unimplemented!()
+            }
+        }
+        Ok(())
+    }
+}
+
+type RpcResult<T> = Result<Response<T>, Status>;
+
+#[derive(Debug, Default)]
+pub struct P9cpuService {}
+
+#[async_trait]
+impl rpc::p9cpu_server::P9cpu for P9cpuService {
+    type StdoutStream = Pin<Box<dyn Stream<Item = Result<rpc::Bytes, Status>> + Send>>;
+    type StderrStream = Pin<Box<dyn Stream<Item = Result<rpc::Bytes, Status>> + Send>>;
+    type NinepForwardStream = Pin<Box<dyn Stream<Item = Result<rpc::Bytes, Status>> + Send>>;
+
+    async fn start(&self, _request: Request<rpc::StartRequest>) -> RpcResult<rpc::Empty> {
+        unimplemented!()
+    }
+
+    async fn stdin(
+        &self,
+        _request: Request<Streaming<rpc::StdinRequest>>,
+    ) -> RpcResult<rpc::Empty> {
+        unimplemented!()
+    }
+
+    async fn stdout(&self, _request: Request<rpc::SessionId>) -> RpcResult<Self::StdoutStream> {
+        unimplemented!()
+    }
+
+    async fn stderr(&self, _request: Request<rpc::SessionId>) -> RpcResult<Self::StderrStream> {
+        unimplemented!()
+    }
+
+    async fn dial(&self, _: Request<rpc::Empty>) -> RpcResult<rpc::SessionId> {
+        unimplemented!()
+    }
+
+    async fn ninep_forward(
+        &self,
+        _request: Request<Streaming<rpc::NinepForwardRequest>>,
+    ) -> RpcResult<Self::NinepForwardStream> {
+        unimplemented!()
+    }
+
+    async fn wait(&self, _request: Request<rpc::SessionId>) -> RpcResult<rpc::Code> {
+        unimplemented!()
+    }
+}

--- a/p9cpu/crates/libp9cpu/src/server/mod.rs
+++ b/p9cpu/crates/libp9cpu/src/server/mod.rs
@@ -1,0 +1,7 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait P9cpuServerT {
+    type Error: std::error::Error;
+    async fn serve(&self, addr: crate::Addr) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
This PR sets up the server framework. The actual logic will be implemented in future PRs.