### PR TITLE
cpud: remove CPU_NAMESPACE

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -5,8 +5,7 @@
 // Package client provides an exec.Command and ssh like interface for cpu sessions.
 // It attempts to cleave as much as possible to the original.
 // The choice between options and environment variables mirrors this effort.
-// For example, the namespace for the remote process is an environment variable,
-// CPU_NAMESPACE. The nonce for the mount protocol back is also an environment variable.
+// For example, the nonce for the mount protocol back is an environment variable.
 // command name and arguments are passed in os.Args
 // The only required parameter for Command() is a host name; if os.Args is empty,
 // the remote server reads SHELL and starts a shell.

--- a/session/doc.go
+++ b/session/doc.go
@@ -13,9 +13,7 @@
 // needed and will set one up.
 //
 // Run will also set up a process namespace via 9p and other mounts,
-// if needed.  If CPU_NAMESPACE is non-empty, it defines the bind
-// mounts from /tmp/cpu.  See the cpu command documentation for more
-// information on how CPU_NAMESPACE is set.  If CPU_FSTAB is set, it
+// if needed. If CPU_FSTAB is set, it
 // is assumed to be a string in fstab(5) format and Run will mount the
 // specified file systems. CPU_FSTAB is most often used for virtiofs
 // mounts from virtual machines.

--- a/session/fns.go
+++ b/session/fns.go
@@ -5,11 +5,9 @@
 package session
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
-	"strings"
 
 	"golang.org/x/sys/unix"
 )
@@ -43,40 +41,4 @@ loop:
 		}
 	}
 	return err
-}
-
-// ParseBinds parses a CPU_NAMESPACE-style string to a
-// slice of Bind structures.
-func ParseBinds(s string) ([]Bind, error) {
-	var b = []Bind{}
-	if len(s) == 0 {
-		return b, nil
-	}
-	binds := strings.Split(s, ":")
-	for i, bind := range binds {
-		if len(bind) == 0 {
-			return nil, fmt.Errorf("bind: element %d is zero length", i)
-		}
-		// If the value is local=remote, len(c) will be 2.
-		// The value might be some weird degenerate form such as
-		// =name or name=. Both are considered to be an error.
-		// The convention is to split on the first =. It is not up
-		// to this code to determine that more than one = is an error
-		// There is no rule that filenames can not contain an '='!
-		c := strings.SplitN(bind, "=", 2)
-		if len(c) == 2 {
-			l, r := c[0], c[1]
-			if len(r) == 0 {
-				return nil, fmt.Errorf("bind: element %d:name in %q: zero-length remote name", i, bind)
-			}
-			if len(l) == 0 {
-				return nil, fmt.Errorf("bind: element %d:name in %q: zero-length local name", i, bind)
-
-			}
-			b = append(b, Bind{Local: c[0], Remote: c[1]})
-			continue
-		}
-		b = append(b, Bind{Local: c[0], Remote: c[0]})
-	}
-	return b, nil
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -5,7 +5,6 @@
 package session
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -14,67 +13,5 @@ func TestDropPrivs(t *testing.T) {
 	s := New("", "/tmp", "/bin/true")
 	if err := s.DropPrivs(); err != nil {
 		t.Fatalf("s.DropPrivs(): %v != nil", err)
-	}
-}
-
-func TestParseBind(t *testing.T) {
-	var tests = []struct {
-		in    string
-		out   []Bind
-		error string
-	}{
-		{in: "", out: []Bind{}},
-		{in: ":", out: []Bind{}, error: "bind: element 0 is zero length"},
-		{in: "l=:", out: []Bind{}, error: "bind: element 0:name in \"l=\": zero-length remote name"},
-		{in: "=r:", out: []Bind{}, error: "bind: element 0:name in \"=r\": zero-length local name"},
-		{
-			in: "/bin",
-			out: []Bind{
-				{Local: "/bin", Remote: "/bin"},
-			},
-		},
-		{
-			in: "/bin", out: []Bind{
-				{Local: "/bin", Remote: "/bin"},
-			},
-		},
-
-		{
-			in: "/bin=/home/user/bin",
-			out: []Bind{
-				{Local: "/bin", Remote: "/home/user/bin"},
-			},
-		},
-		{
-			in: "/bin=/home/user/bin:/home",
-			out: []Bind{
-				{Local: "/bin", Remote: "/home/user/bin"},
-				{Local: "/home", Remote: "/home"},
-			},
-		},
-	}
-	for i, tt := range tests {
-		b, err := ParseBinds(tt.in)
-		t.Logf("Test %d:%q => (%q, %v), want %q", i, tt.in, b, err, tt.out)
-		if len(tt.error) == 0 {
-			if err != nil {
-				t.Errorf("%d:ParseBinds(%q): err %v != nil", i, tt.in, err)
-				continue
-			}
-			if !reflect.DeepEqual(b, tt.out) {
-				t.Errorf("%d:ParseBinds(%q): Binds %q != %q", i, tt.in, b, tt.out)
-				continue
-			}
-			continue
-		}
-		if err == nil {
-			t.Errorf("%d:ParseBinds(%q): err nil != %q", i, tt.in, tt.error)
-			continue
-		}
-		if err.Error() != tt.error {
-			t.Errorf("%d:ParseBinds(%q): err %s != %s", i, tt.in, err.Error(), tt.error)
-			continue
-		}
-
 	}
 }


### PR DESCRIPTION
This commit follows 0de8d08 ("client: only pass CPU_FSTAB to cpud") and removes all CPU_NAMESPACE related codes from the cpud side.