### PR TITLE
Revert "mount: allow bind-mounting a file to a file"

### DIFF
--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -8,7 +8,6 @@
 package mount
 
 import (
-	"errors"
 	"os"
 	"syscall"
 	"testing"
@@ -20,8 +19,8 @@ func TestMkdir(t *testing.T) {
 	// Call Mount with a one-line fstab with a bogus mount point. It should do nothing but return
 	// the mkdir error
 	var fstab = "a /dev/zero/x none defaults 0 0"
-	if err := Mount(fstab); !errors.Is(err, syscall.ENOTDIR) {
-		t.Fatalf("mount(%v): %v != %v", fstab, err, syscall.ENOTDIR)
+	if err := Mount(fstab); err == nil {
+		t.Fatalf("mount(%v): want err, got nil", fstab)
 	}
 }
 


### PR DESCRIPTION
This reverts commit 39930095d694caada331a6cc7c316bb531501d13.

That commit would create directories and files as needed, following the original which would create directories as needed.

Both this commit and the original, with MkdirAll, were a mistake, because different users, at different times, could conflict.

E.g., a ubuntu container might have a directory named /etc/ssh/x, and an alpine container might have a file named /etc/ssh/x, and in each case, with this code, one would modify the local root in a way which would break the other one. Since we now routinely run different docker images on the same node at the same time, this modification, and the original code, are unacceptable.

Should you need a file named, e.g., /etc/resolv.conf, that you can bind over, there are a few options:
o modify the initramfs to include /etc/resolv.conf, and bind over that o append a cpio with the desired contents of the initramfs to
  use on boot
o run a cpu command which sets up the desired directory structure.
  Recall that one can omit /etc from the namespace of a cpu
  command, allowing one to modify the node's /etc; or, /etc
  should be visible in /tmp/local/etc.

I.e., /tmp/cpu/local has the local file system; or, you can have a simple statically linked program which does the work, and run a cpu with a minimal namespace to set that up.

It's a shame that this is so complex, but it goes back to Linux's not very good design for private namespaces. Linux private name spaces are bit of a hack on top of mount, whereas Plan 9's namespaces are implemented via a namespace walking mechanism in the kernel.