### PR TITLE
Let callers provide an p9.Attacher

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -145,7 +145,7 @@ func Command(host string, args ...string) *Cmd {
 type Set func(*Cmd) error
 
 // WithServer allows setting custom 9P servers.
-// One use: should users with to serve from a flattened
+// One use: should users wish to serve from a flattened
 // docker container saved as a cpio or tar.
 func WithServer(a p9.Attacher) Set {
 	return func(c *Cmd) error {

--- a/client/cpu9p_unix.go
+++ b/client/cpu9p_unix.go
@@ -17,7 +17,7 @@ import (
 )
 
 // SetAttr implements p9.File.SetAttr.
-func (l *cpu9p) SetAttr(mask p9.SetAttrMask, attr p9.SetAttr) error {
+func (l *CPU9P) SetAttr(mask p9.SetAttrMask, attr p9.SetAttr) error {
 	var err error
 	// Any or ALL can be set.
 	// A setattr could include things to set,

--- a/client/cpu9p_unix_test.go
+++ b/client/cpu9p_unix_test.go
@@ -43,7 +43,7 @@ func Test9pUnix(t *testing.T) {
 		DataVersion: true,
 	}
 
-	c := &cpu9p{
+	c := &CPU9P{
 		path: f,
 	}
 
@@ -205,7 +205,7 @@ func Test9pRemove(t *testing.T) {
 	if err := ioutil.WriteFile(f, []byte("hi"), 0666); err != nil {
 		t.Fatalf(`ioutil.WriteFile(%q, "hi", 0666): %v != nil`, f, err)
 	}
-	c := &cpu9p{
+	c := &CPU9P{
 		path: f,
 	}
 
@@ -224,7 +224,7 @@ func Test9pUnlinkat(t *testing.T) {
 	if err := ioutil.WriteFile(f, []byte("hi"), 0666); err != nil {
 		t.Fatalf(`ioutil.WriteFile(%q, "hi", 0666): %v != nil`, f, err)
 	}
-	c := &cpu9p{
+	c := &CPU9P{
 		path: d,
 	}
 
@@ -243,13 +243,13 @@ func Test9pRenameAt(t *testing.T) {
 	if err := ioutil.WriteFile(f, []byte("hi"), 0666); err != nil {
 		t.Fatalf(`ioutil.WriteFile(%q, "hi", 0666): %v != nil`, f, err)
 	}
-	c := &cpu9p{
+	c := &CPU9P{
 		path: filepath.Join(d, "nd"),
 	}
 	if err := os.Mkdir(c.path, 0777); err != nil {
 		t.Fatalf("Mkdir(%q, 0777): %v != nil", c.path, err)
 	}
-	oldPath := &cpu9p{
+	oldPath := &CPU9P{
 		path: d,
 	}
 	if err := oldPath.RenameAt("a", c, "z"); err != nil {

--- a/client/getattr_darwin.go
+++ b/client/getattr_darwin.go
@@ -23,7 +23,7 @@ import (
 // GetAttr implements p9.File.GetAttr.
 //
 // Not fully implemented.
-func (l *cpu9p) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+func (l *CPU9P) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
 	qid, fi, err := l.info()
 	if err != nil {
 		return qid, p9.AttrMask{}, p9.Attr{}, err

--- a/client/getattr_linux.go
+++ b/client/getattr_linux.go
@@ -23,7 +23,7 @@ import (
 // GetAttr implements p9.File.GetAttr.
 //
 // Not fully implemented.
-func (l *cpu9p) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+func (l *CPU9P) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
 	qid, fi, err := l.info()
 	if err != nil {
 		return qid, p9.AttrMask{}, p9.Attr{}, err

--- a/client/srv.go
+++ b/client/srv.go
@@ -63,7 +63,7 @@ func (c *Cmd) srv(l net.Listener) error {
 			log.SetFlags(log.Ltime | log.Lmicroseconds)
 			ulog.Log = log.New(DumpWriter, "9p", log.Ltime|log.Lmicroseconds)
 		}
-		if err := p9.NewServer(&cpu9p{path: c.Root}, p9.WithServerLogger(ulog.Log)).Handle(s, s); err != nil {
+		if err := p9.NewServer(&CPU9P{path: c.Root}, p9.WithServerLogger(ulog.Log)).Handle(s, s); err != nil {
 			if err != io.EOF {
 				log.Printf("Serving cpu remote: %v", err)
 				return err
@@ -71,7 +71,8 @@ func (c *Cmd) srv(l net.Listener) error {
 		}
 		return nil
 	}
-	if err := p9.NewServer(&cpu9p{path: c.Root}).Handle(s, s); err != nil {
+
+	if err := p9.NewServer(c.fileServer).Handle(s, s); err != nil {
 		if err != io.EOF {
 			log.Printf("Serving cpu remote: %v", err)
 			return err


### PR DESCRIPTION
This is preparing for serving from a flattened docker container

Also, export CPU9P, external users will need it.