### PR TITLE
Follow symlinks when mounting

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -63,12 +63,10 @@ func mount(m mounter, fstab string) error {
 		// surprise! It turns out that correct behavior from mount is to follow symlinks
 		// on where and device and use that. That's why /bin -> /usr/bin gets mounted
 		// correctly.
-		 w, err := filepath.EvalSymlinks(where)
-		if  err == nil {
+		if w, err := filepath.EvalSymlinks(where); err == nil {
 			where = w
 		}
-		w, err = filepath.EvalSymlinks(dev)
-		if  err == nil {
+		if w, err := filepath.EvalSymlinks(dev); err == nil {
 			dev = w
 		}
 

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -11,6 +11,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -58,6 +59,19 @@ func mount(m mounter, fstab string) error {
 		// This note is here in case someone gets confused in the future.
 		// Setting MS_PRIVATE will get an EINVAL.
 		dev, where, fstype, opts := f[0], f[1], f[2], f[3]
+
+		// surprise! It turns out that correct behavior from mount is to follow symlinks
+		// on where and device and use that. That's why /bin -> /usr/bin gets mounted
+		// correctly.
+		 w, err := filepath.EvalSymlinks(where)
+		if  err == nil {
+			where = w
+		}
+		w, err = filepath.EvalSymlinks(dev)
+		if  err == nil {
+			dev = w
+		}
+
 		// The man page implies that the Linux kernel handles flags of "defaults"
 		// we do no further manipulation of opts.
 		flags, data := parse(opts)

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -9,16 +9,17 @@ package mount
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 
 	"golang.org/x/sys/unix"
 )
 
-func TestMkdir(t *testing.T) {
-	// Call Mount with a one-line fstab with a bogus mount point. It should do nothing but return
-	// the mkdir error
-	var fstab = "a /dev/zero/x none defaults 0 0"
+func TestNoDir(t *testing.T) {
+	bad := filepath.Join(t.TempDir(), "nonexistent")
+	// Call Mount with a one-line fstab with a bogus mount point.
+	var fstab = "a " + bad + " none defaults 0 0"
 	if err := Mount(fstab); err == nil {
 		t.Fatalf("mount(%v): want err, got nil", fstab)
 	}


### PR DESCRIPTION
We did not realize this, but the convention nowadays (and for how long? we are not sure) is to follow
symlinks when mounting.

This does result in duplicate mounts at times, e.g. /bin -> /usr/bin means we mount /usr/bin twice, but this seems to to do harm.