### PR TITLE
cpud: server: add flags to cpud -remote

### DIFF
--- a/cmds/cpud/main_linux.go
+++ b/cmds/cpud/main_linux.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -111,7 +112,7 @@ func main() {
 				log.Fatal(err)
 			}
 		}
-		if err := serve(os.Args[0]); err != nil {
+		if err := serve(os.Args[0], fmt.Sprintf("-d=%t", *debug)); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -153,8 +153,8 @@ func register(network, addr string, timeout time.Duration) error {
 	return nil
 }
 
-func serve(cpud string) error {
-	s, err := server.New(*pubKeyFile, *hostKeyFile, cpud)
+func serve(cpud string, cpudArgs ...string) error {
+	s, err := server.New(*pubKeyFile, *hostKeyFile, cpud, cpudArgs...)
 	if err != nil {
 		log.Printf(`New(%q, %q): %v`, *pubKeyFile, *hostKeyFile, err)
 		hang()

--- a/server/server.go
+++ b/server/server.go
@@ -60,10 +60,12 @@ func errval(err error) error {
 	return err
 }
 
-func handler(s ssh.Session, cpud string) {
+func handler(s ssh.Session, cpud string, cpudArgs ...string) {
 	a := s.Command()
 	verbose("handler: cmd is %q", a)
-	cmd := command(cpud, append([]string{"-remote"}, a...)...)
+	cmdArgs := append([]string{"-remote"}, cpudArgs...)
+	cmdArgs = append(cmdArgs, a...)
+	cmd := command(cpud, cmdArgs...)
 
 	sigChan := make(chan ssh.Signal, 1)
 	defer close(sigChan)
@@ -138,7 +140,7 @@ func handler(s ssh.Session, cpud string) {
 
 // New sets up a cpud. cpud is really just an SSH server with a special
 // handler and support for port forwarding for the 9p port.
-func New(publicKeyFile, hostKeyFile, cpud string) (*ssh.Server, error) {
+func New(publicKeyFile, hostKeyFile, cpud string, cpudArgs ...string) (*ssh.Server, error) {
 	verbose("configure SSH server")
 	publicKeyOption := func(ctx ssh.Context, key ssh.PublicKey) bool {
 		data, err := ioutil.ReadFile(publicKeyFile)
@@ -175,7 +177,7 @@ func New(publicKeyFile, hostKeyFile, cpud string) (*ssh.Server, error) {
 			"cancel-tcpip-forward": forwardHandler.HandleSSHRequest,
 		},
 		Handler: func(s ssh.Session) {
-			handler(s, cpud)
+			handler(s, cpud, cpudArgs...)
 		},
 	}
 


### PR DESCRIPTION
Currently the cpud server starts commands by executing `cpud -remote` plus the command string sent from the client. There is no way to start `cpud -remote` with `-d` on.

This patch adds `-d` to `cpud -remote` if the cpud server is running with `-d`.