### PR TITLE
cpud: default to building cpud with mDNS enabled

### DIFF
--- a/cmds/cpud/main_mdns_linux.go
+++ b/cmds/cpud/main_mdns_linux.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build mDNS
+//go:build !nomDNS
 
 package main
 
@@ -59,7 +59,7 @@ func servemDNS(s *ssh.Server) error {
 	if err != nil {
 		return fmt.Errorf("Could not advertise with dns-sd: %w", err)
 	}
-//	defer ds.Unregister()
+	//	defer ds.Unregister()
 
 	wrap := &handleWrapper{
 		handle: s.Handler,

--- a/cmds/cpud/serve_mdns_test.go
+++ b/cmds/cpud/serve_mdns_test.go
@@ -1,5 +1,5 @@
-//go:build mDNS
-// +build mDNS
+//go:build !nomDNS
+// +build !nomDNS
 
 package main
 


### PR DESCRIPTION
This relies on a double negative:
// go:build !nomDNS

u-root is not properly handling
-tags mDNS
in the command line, and we kind of need this, so
I will leave it to Google to work around it.