### PR TITLE
Move to golang x term

### DIFF
--- a/client/fns.go
+++ b/client/fns.go
@@ -260,7 +260,11 @@ func parseBinds(s string) (string, error) {
 	if len(s) == 0 {
 		return fstab, nil
 	}
-	tmpMnt := os.TempDir()
+	// This is bit tricky. For now we have to assume
+	// cpud is on Linux, since only Linux has the features we
+	// need for private name spaces. Therefore, to run this test on
+	// (e.g.) Darwin, we just use /tmp, not os.TempDir()
+	tmpMnt := "/tmp"
 	binds := strings.Split(s, ":")
 	for i, bind := range binds {
 		if len(bind) == 0 {

--- a/client/fns_test.go
+++ b/client/fns_test.go
@@ -6,7 +6,6 @@ package client
 
 import (
 	"errors"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -40,7 +39,11 @@ func TestVsockIdPort(t *testing.T) {
 
 func TestParseBinds(t *testing.T) {
 	td := func(s string) string {
-		return path.Join(os.TempDir(), s)
+		// Because cpud only runs on Linux, for now,
+		// the name of tmp is /tmp, not os.TempDir.
+		// This allows running many of these tests on
+		// non-Linux systems.
+		return path.Join("/tmp", s)
 	}
 	for _, tt := range []struct {
 		namespace string

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mdlayher/vsock v1.2.1
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad
+	golang.org/x/term v0.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20220722155259-a9ba230a4035/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This works on darwin and linux. 

The golang x term package has less drama :-) but less capability than u-root termios (which we don't need or use, so who cares)