### PR TITLE
ds/: cleanup and make more idiomatic

### DIFF
--- a/cmds/decpu/decpu.go
+++ b/cmds/decpu/decpu.go
@@ -176,7 +176,7 @@ func newCPU(host, port string, args ...string) error {
 func main() {
 	flags()
 	args := flag.Args()
-	host := ds.DsDefault
+	host := ds.Default
 	port := *sp
 	a := []string{}
 	if len(args) > 0 {
@@ -184,7 +184,7 @@ func main() {
 		a = args[1:]
 	}
 	if host == "." {
-		host = ds.DsDefault
+		host = ds.Default
 	}
 	if len(a) == 0 {
 		if *numCPUs > 1 {

--- a/ds/ds_test.go
+++ b/ds/ds_test.go
@@ -99,7 +99,7 @@ func TestDnsSdStart(t *testing.T) {
 	}
 
 	// default uri parse
-	if _, err := Parse(DsDefault); err != nil {
+	if _, err := Parse(Default); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Names like dsXyz stutter; rename them to patterns such as xyz.

Export Timeout so callers can have some idea what the value is.