### PR TITLE
Workflow go multiarch build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,10 @@ on:
 jobs:
 
   build:
+    strategy:
+      matrix:
+        arch: [amd64, arm, arm64, riscv64]
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -19,7 +23,9 @@ jobs:
         go-version: "1.20"
 
     - name: Build
-      run: go build -v ./...
+      run: |
+        go build -v ./...
+        (cd cmds/cpud && GOARCH=${{ matrix.arch }} go build -o cpud.${{ matrix.arch }} .)
 
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION
I'd like to get all cpud binaries into docker containers. This would make it easier to run docker on m2 mac.