### PR TITLE
minor staticcheck fixes

### DIFF
--- a/client/cpio9p.go
+++ b/client/cpio9p.go
@@ -329,7 +329,7 @@ func (l *CPIO9PFID) Readlink() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	link := make([]byte, r.FileSize, r.FileSize)
+	link := make([]byte, r.FileSize)
 	v("cpio:readlink: %d byte link", len(link))
 	if n, err := r.ReadAt(link, 0); err != nil || n != len(link) {
 		v("cpio:readlink: fail with (%d,%v)", n, err)

--- a/cmds/cpud/serve.go
+++ b/cmds/cpud/serve.go
@@ -34,7 +34,7 @@ type modifier struct {
 }
 
 func (m *modifier) String() string {
-	return fmt.Sprintf("%s", m.name)
+	return m.name
 }
 
 var (


### PR DESCRIPTION
S1019 - Simplify make call by omitting redundant arguments S1025 - Don’t use fmt.Sprintf("%s", x) unnecessarily