### PR TITLE
Add flag -useKey for ssh without keys

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -48,23 +48,24 @@ type Cmd struct {
 	// be set directly.
 	Host string
 	// HostName as found in .ssh/config; set to Host if not found
-	HostName       string
-	Args           []string
-	Root           string
-	HostKeyFile    string
-	PrivateKeyFile string
-	Port           string
-	Timeout        time.Duration
-	Env            []string
-	SessionIn      io.WriteCloser
-	SessionOut     io.Reader
-	SessionErr     io.Reader
-	Stdin          io.Reader
-	Stdout         io.Writer
-	Stderr         io.Writer
-	Row            int
-	Col            int
-	hasTTY         bool // Set if we have a TTY
+	HostName          string
+	Args              []string
+	Root              string
+	HostKeyFile       string
+	PrivateKeyFile    string
+	DisablePrivateKey bool
+	Port              string
+	Timeout           time.Duration
+	Env               []string
+	SessionIn         io.WriteCloser
+	SessionOut        io.Reader
+	SessionErr        io.Reader
+	Stdin             io.Reader
+	Stdout            io.Writer
+	Stderr            io.Writer
+	Row               int
+	Col               int
+	hasTTY            bool // Set if we have a TTY
 	// NameSpace is a string as defined in the cpu documentation.
 	NameSpace string
 	// FSTab is an fstab(5)-format string
@@ -214,6 +215,15 @@ func WithTimeout(timeout string) Set {
 func WithPrivateKeyFile(key string) Set {
 	return func(c *Cmd) error {
 		c.PrivateKeyFile = key
+		return nil
+	}
+}
+
+// WithDisablePrivateKey disables using private keys to encrypt the SSH
+// connection.
+func WithDisablePrivateKey(disable bool) Set {
+	return func(c *Cmd) error {
+		c.DisablePrivateKey = disable
 		return nil
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -40,3 +40,16 @@ func TestQuoteArg(t *testing.T) {
 		}
 	}
 }
+
+func TestCmdWithDisablePrivateKey(t *testing.T) {
+	c := Command("someserver", "bash")
+	if c.DisablePrivateKey {
+		t.Fatal("DisablePrivateKey of Cmd created by Command() is expected to be false, got true")
+	}
+	if err := c.SetOptions(WithDisablePrivateKey(true)); err != nil {
+		t.Fatalf("WithDisablePrivateKey returns unexpected err %v", err)
+	}
+	if !c.DisablePrivateKey {
+		t.Fatal("WithDisablePrivateKey(true) should set DisablePrivateKey to true, got false")
+	}
+}

--- a/client/fns.go
+++ b/client/fns.go
@@ -65,6 +65,10 @@ func (n nonce) String() string {
 // UserKeyConfig sets up authentication for a User Key.
 // It is required in almost all cases.
 func (c *Cmd) UserKeyConfig() error {
+	if c.DisablePrivateKey {
+		verbose("Not using a key file to encrypt the ssh connection")
+		return nil
+	}
 	kf := c.PrivateKeyFile
 	if len(kf) == 0 {
 		kf = config.Get(c.Host, "IdentityFile")

--- a/client/fns_test.go
+++ b/client/fns_test.go
@@ -110,3 +110,16 @@ func TestJoinFSTab(t *testing.T) {
 		}
 	}
 }
+
+func TestUserKeyConfigWithDisablePrivateKey(t *testing.T) {
+	cmd := &Cmd{
+		PrivateKeyFile:    DefaultKeyFile,
+		DisablePrivateKey: true,
+	}
+	if err := cmd.UserKeyConfig(); err != nil {
+		t.Fatalf("UserKeyConfig() returns unexpected err: %v", err)
+	}
+	if len(cmd.config.Auth) != 0 {
+		t.Fatalf("cmd.config.Auth: got %v, want []", cmd.config.Auth)
+	}
+}

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -38,6 +38,7 @@ var (
 	fstab       = flag.String("fstab", "", "pass an fstab to the cpud")
 	hostKeyFile = flag.String("hk", "" /*"/etc/ssh/ssh_host_rsa_key"*/, "file for host key")
 	keyFile     = flag.String("key", "", "key file")
+	useKey      = flag.Bool("useKey", true, "Use key file to encrypt the ssh connection")
 	namespace   = flag.String("namespace", "/lib:/lib64:/usr:/bin:/etc:/home", "Default namespace for the remote process -- set to none for none")
 	network     = flag.String("net", "", "network type to use. Defaults to whatever the cpu client defaults to")
 	port        = flag.String("sp", "", "cpu default port")
@@ -80,6 +81,9 @@ func flags() {
 // getKeyFile picks a keyfile if none has been set.
 // It will use sshconfig, else use a default.
 func getKeyFile(host, kf string) string {
+	if !*useKey {
+		return ""
+	}
 	verbose("getKeyFile for %q", kf)
 	if len(kf) == 0 {
 		kf = config.Get(host, "IdentityFile")
@@ -143,6 +147,7 @@ func newCPU(host string, args ...string) (retErr error) {
 	client.Debug9p = *dbg9p
 
 	if err := c.SetOptions(
+		client.WithDisablePrivateKey(!*useKey),
 		client.WithPrivateKeyFile(*keyFile),
 		client.WithHostKeyFile(*hostKeyFile),
 		client.WithPort(*port),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,9 +20,23 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
+	s, err := New("key.pub", "", os.Args[0])
+	if err != nil {
+		t.Fatalf(`New("key.pub", "", %q): %v != nil`, os.Args[0], err)
+	}
+	if s.PublicKeyHandler == nil {
+		t.Fatalf(`New("key.pub", "", %q) returns a server without a public key handler`, os.Args[0])
+	}
+	t.Logf("New server: %v", s)
+}
+
+func TestNewServerWithoutKey(t *testing.T) {
 	s, err := New("", "", os.Args[0])
 	if err != nil {
 		t.Fatalf(`New("", "", %q): %v != nil`, os.Args[0], err)
+	}
+	if s.PublicKeyHandler != nil {
+		t.Fatalf(`New("", "", %q) returns a server with a public key handler`, os.Args[0])
 	}
 	t.Logf("New server: %v", s)
 }


### PR DESCRIPTION
In some fully isolated environments, the key used to encrypt the ssh connection is redundant. With this commit, we can use cpud/cpu without a key file by
* server: ./cpud -pk=
* client: ./cpu -useKey=false $HOST bash

-useKey as default is True.