### PR TITLE
Revert "nfs: remove the cacheHelper provided by go-nfs (#272)"

### DIFF
--- a/client/union.go
+++ b/client/union.go
@@ -42,6 +42,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/u-root/u-root/pkg/cpio"
 	nfs "github.com/willscott/go-nfs"
+	nfshelper "github.com/willscott/go-nfs/helpers"
 )
 
 // Chroot. This is deprecated, so we don't bother.
@@ -750,8 +751,9 @@ func SrvNFS(cl *Cmd, n string, dir string) (func() error, string, error) {
 	}
 	handler := NewNullAuthHandler(l, COS{mem}, u.String())
 	verbose("uuid is %q", u.String())
+	cacheHelper := nfshelper.NewCachingHandler(handler, 1024)
 	f := func() error {
-		return nfs.Serve(l, handler)
+		return nfs.Serve(l, cacheHelper)
 	}
 	fstab := fmt.Sprintf("127.0.0.1:%s /tmp/cpu nfs rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,nolock,proto=tcp,port=%d,timeo=600,retrans=2,sec=sys,mountaddr=127.0.0.1,mountvers=3,mountport=%d,mountproto=tcp,local_lock=all,addr=127.0.0.1 0 0\n", u, portnfs, portnfs)
 	return f, fstab, nil


### PR DESCRIPTION
This reverts commit 0edd79a06ae2f718a12a7df400a6c9fededec89e.

Because their nfs cache helper does not work well, but without it, things are even worse.

I'll have to write my own, less fancy version. I'm just going to use a map, since cpu sessions are not long term, and I can let the processor do its thing with its cache, rather than trying to outsmart it and get it wrong, as go-nfs does now.