### PR TITLE
Cpu namespace over ssh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@
 
 # whatever
 *~
+*=
+*tar
+cpuns
+*uck

--- a/client/client.go
+++ b/client/client.go
@@ -159,10 +159,7 @@ func WithServer(a p9.Attacher) Set {
 	}
 }
 
-// With9P enables the 9P2000 server in cpu.
-// The server is by default disabled. Ninep is sticky; if set by,
-// e.g., WithNameSpace, the Principle of Least Confusion argues
-// that it should remain set. Hence, we || it with its current value.
+// With9P enables the 9P2000 server in cpu. The server is by default disabled.
 func With9P(p9 bool) Set {
 	return func(c *Cmd) error {
 		c.Ninep = p9
@@ -171,8 +168,7 @@ func With9P(p9 bool) Set {
 }
 
 // WithNameSpace sets the namespace to Cmd.There is no default: having some default
-// violates the principle of least surprise for package users. If ns is non-empty
-// the Ninep is forced on.
+// violates the principle of least surprise for package users.
 func WithNameSpace(ns string) Set {
 	return func(c *Cmd) error {
 		c.NameSpace = ns

--- a/client/client.go
+++ b/client/client.go
@@ -124,9 +124,10 @@ func Command(host string, args ...string) *Cmd {
 		col, row = c, r
 	}
 
+	h, u := GetHostUser(host)
 	return &Cmd{
 		Host:     host,
-		HostName: GetHostName(host),
+		HostName: h,
 		Args:     args,
 		Port:     DefaultPort,
 		Timeout:  defaultTimeOut,
@@ -136,7 +137,7 @@ func Command(host string, args ...string) *Cmd {
 		Row:      row,
 		Col:      col,
 		config: ssh.ClientConfig{
-			User:            os.Getenv("USER"),
+			User:            u,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		},
 		hasTTY:  hasTTY,

--- a/client/client.go
+++ b/client/client.go
@@ -411,6 +411,7 @@ func (c *Cmd) Dial() error {
 	}
 	if len(c.FSTab) > 0 {
 		c.Env = append(c.Env, "CPU_FSTAB="+c.FSTab)
+		c.Env = append(c.Env, "LC_GLENDA_CPU_FSTAB="+c.FSTab)
 	}
 
 	return nil

--- a/client/client.go
+++ b/client/client.go
@@ -431,7 +431,7 @@ func (c *Cmd) Start() error {
 	}
 	// Set up terminal modes
 	modes := ssh.TerminalModes{
-		ssh.ECHO:          0,     // disable echoing
+		ssh.ECHO:          1,     // do not disable echoing!
 		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
 		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
 	}

--- a/client/fns.go
+++ b/client/fns.go
@@ -84,7 +84,7 @@ func (c *Cmd) UserKeyConfig() error {
 	}
 	key, err := os.ReadFile(kf)
 	if err != nil {
-		return fmt.Errorf("unable to read private key %q: %v", kf, err)
+		return fmt.Errorf("unable to read private key %q: %w", kf, err)
 	}
 
 	signer, err := ssh.ParsePrivateKey(key)

--- a/client/union9p.go
+++ b/client/union9p.go
@@ -112,7 +112,7 @@ func NewUnion9P(mounts []UnionMount) (*Union9P, error) {
 	root := union9PFID{}
 	root.f = &root
 	u := &Union9P{
-		mounts: append([]UnionMount{UnionMount{walk: []string{"/"}, mount: &root}}, mounts...),
+		mounts: append([]UnionMount{{walk: []string{"/"}, mount: &root}}, mounts...),
 	}
 	root.u = u
 
@@ -163,7 +163,7 @@ func (u *union9PFID) Walk(names []string) ([]p9.QID, p9.File, error) {
 	v("union9p: walk(%q)", names)
 	if len(names) == 0 {
 		v("union9p:clonewalk")
-		return []p9.QID{p9.QID{Type: p9.TypeDir, Path: 1, Version: 0}}, &union9PFID{u: u.u, f: u.f}, nil
+		return []p9.QID{{Type: p9.TypeDir, Path: 1, Version: 0}}, &union9PFID{u: u.u, f: u.f}, nil
 	}
 	ix := -1
 	for x, bind := range u.u.mounts {

--- a/client/union9p_test.go
+++ b/client/union9p_test.go
@@ -23,7 +23,7 @@ func TestUnion9PWalkReadlink(t *testing.T) {
 	}
 	t.Logf("root:%v", c)
 
-	u, err := NewUnion9P([]UnionMount{UnionMount{walk: []string{}, mount: c}})
+	u, err := NewUnion9P([]UnionMount{{walk: []string{}, mount: c}})
 
 	if err != nil {
 		t.Fatalf("NewUnion9P: got %v, want nil", err)
@@ -65,7 +65,7 @@ func TestUnion9POne(t *testing.T) {
 	}
 	t.Logf("root:%v", c)
 
-	u, err := NewUnion9P([]UnionMount{UnionMount{walk: []string{}, mount: c}})
+	u, err := NewUnion9P([]UnionMount{{walk: []string{}, mount: c}})
 
 	if err != nil {
 		t.Fatalf("NewUnion9P: got %v, want nil", err)
@@ -259,8 +259,8 @@ func TestUnion9PTwoCPIO(t *testing.T) {
 	t.Logf("root:%v", b)
 
 	u, err := NewUnion9P([]UnionMount{
-		UnionMount{walk: []string{"home"}, mount: b},
-		UnionMount{walk: []string{}, mount: a},
+		{walk: []string{"home"}, mount: b},
+		{walk: []string{}, mount: a},
 	})
 
 	if err != nil {
@@ -313,8 +313,8 @@ func TestUnion9PTwoCPIOSymlinkAtRoot(t *testing.T) {
 	t.Logf("root:%v", b)
 
 	u, err := NewUnion9P([]UnionMount{
-		UnionMount{walk: []string{"home"}, mount: b},
-		UnionMount{walk: []string{}, mount: a},
+		{walk: []string{"home"}, mount: b},
+		{walk: []string{}, mount: a},
 	})
 
 	if err != nil {
@@ -367,9 +367,9 @@ func TestUnion9PTwoCPIOEmptyHome(t *testing.T) {
 	t.Logf("root:%v", b)
 
 	u, err := NewUnion9P([]UnionMount{
-		UnionMount{walk: []string{"home"}, mount: b},
-		UnionMount{walk: []string{"root"}, mount: b},
-		UnionMount{walk: []string{}, mount: a},
+		{walk: []string{"home"}, mount: b},
+		{walk: []string{"root"}, mount: b},
+		{walk: []string{}, mount: a},
 	})
 
 	if err != nil {

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -115,9 +115,6 @@ func getHostName(host string) string {
 }
 
 // getPort gets a port.
-// The rules here are messy, since config.Get will return "22" if
-// there is no entry in .ssh/config. 22 is not allowed. So in the case
-// of "22", convert to defaultPort
 func getPort(host, port string) string {
 	p := port
 	verbose("getPort(%q, %q)", host, port)
@@ -127,7 +124,7 @@ func getPort(host, port string) string {
 			p = cp
 		}
 	}
-	if len(p) == 0 || p == "22" {
+	if len(p) == 0  {
 		p = defaultPort
 		verbose("getPort: return default %q", p)
 	}

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -114,7 +114,7 @@ func getPort(host, port string) string {
 			p = cp
 		}
 	}
-	if len(p) == 0 {
+	if len(p) == 0  {
 		p = defaultPort
 		verbose("getPort: return default %q", p)
 	}

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -137,7 +137,7 @@ func newCPU(host string, args ...string) (retErr error) {
 	// Also, because of how sshd works, we need to pass in
 	// a PWD that is correct; otherwise it gets lost, since
 	// since ssh wants to simulate a login..
-	if *ssh {
+	if *ssh && *srvnfs {
 		env := append(os.Environ(), "CPU_PWD="+os.Getenv("PWD"))
 		envargs := "-env=" + strings.Join(env, "\n")
 		args = append([]string{"cpuns", envargs}, args...)
@@ -284,7 +284,7 @@ func main() {
 		verbose("turning ninep off for ssh usage")
 		*ninep = false
 	}
-	if *port == "22" && !*srvnfs {
+	if *port == "22" && !*srvnfs && len(*namespace) > 0 {
 		verbose("turning srvnfs on for ssh usage")
 		*srvnfs = true
 	}

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -49,7 +49,7 @@ var (
 	srvnfs   = flag.Bool("nfs", false, "start nfs")
 	cpioRoot = flag.String("cpio", "", "cpio initrd")
 
-	ssh = flag.Bool("ssh", false, "server is sshd, not cpud")
+	sshd = flag.Bool("sshd", false, "server is sshd, not cpud")
 
 	// v allows debug printing.
 	// Do not call it directly, call verbose instead.
@@ -137,7 +137,7 @@ func newCPU(host string, args ...string) (retErr error) {
 	// Also, because of how sshd works, we need to pass in
 	// a PWD that is correct; otherwise it gets lost, since
 	// since ssh wants to simulate a login..
-	if *ssh && *srvnfs {
+	if *sshd && *srvnfs {
 		env := append(os.Environ(), "CPU_PWD="+os.Getenv("PWD"))
 		envargs := "-env=" + strings.Join(env, "\n")
 		args = append([]string{"cpuns", envargs}, args...)
@@ -289,7 +289,7 @@ func main() {
 		*srvnfs = true
 	}
 	if *port == "22" {
-		*ssh = true
+		*sshd = true
 	}
 	verbose("connecting to %q port %q", host, *port)
 	if err := newCPU(host, a...); err != nil {

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -257,6 +257,18 @@ func main() {
 	*keyFile = getKeyFile(host, *keyFile)
 	*port = getPort(host, *port)
 
+	// If we care connecting on port 22, 9p is not an option.
+	// It goes back to the way we send the Nonce, and that is
+	// too hard to fix, and not worth fixing, as 9p is just too
+	// slow.
+	if *port == "22" && *ninep {
+		verbose("turning ninep off for ssh usage")
+		*ninep = false
+	}
+	if *port == "22" && !*srvnfs {
+		verbose("turning srvnfs on for ssh usage")
+		*srvnfs = true
+	}
 	verbose("connecting to %q port %q", host, *port)
 	if err := newCPU(host, a...); err != nil {
 		e := 1

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -116,7 +116,7 @@ func getPort(host, port string) string {
 			p = cp
 		}
 	}
-	if len(p) == 0  {
+	if len(p) == 0 {
 		p = defaultPort
 		verbose("getPort: return default %q", p)
 	}
@@ -134,8 +134,12 @@ func newCPU(host string, args ...string) (retErr error) {
 	// If running over ssh, *srvnfs is true, then
 	// we need to start cpuns, and pass the environment
 	// as an argument.
+	// Also, because of how sshd works, we need to pass in
+	// a PWD that is correct; otherwise it gets lost, since
+	// since ssh wants to simulate a login..
 	if *ssh {
-		envargs := "-env=" + strings.Join(os.Environ(), "\n")
+		env := append(os.Environ(), "CPU_PWD="+os.Getenv("PWD"))
+		envargs := "-env=" + strings.Join(env, "\n")
 		args = append([]string{"cpuns", envargs}, args...)
 	}
 	c := client.Command(host, args...)

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -49,6 +49,7 @@ var (
 	srvnfs   = flag.Bool("nfs", false, "start nfs")
 	cpioRoot = flag.String("cpio", "", "cpio initrd")
 
+	ssh = flag.Bool("ssh", false, "ssh only, no internal 9p, nfs, or mounts")
 	sshd = flag.Bool("sshd", false, "server is sshd, not cpud")
 
 	// v allows debug printing.
@@ -80,6 +81,11 @@ func flags() {
 		*dbg9p = true
 		ulog.Log = log.New(dumpWriter, "", log.Ltime|log.Lmicroseconds)
 		v = ulog.Log.Printf
+	}
+	if *ssh {
+		*srvnfs, *ninep, *sshd = false, false, true
+		*namespace = ""
+		log.Printf("Running basic ssh protocol; no mounts")
 	}
 }
 

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -46,7 +46,7 @@ var (
 	timeout9P   = flag.String("timeout9p", "100ms", "time to wait for the 9p mount to happen.")
 	ninep       = flag.Bool("9p", true, "Enable the 9p mount in the client")
 
-	srvnfs = flag.Bool("nfs", false, "start nfs")
+	srvnfs   = flag.Bool("nfs", false, "start nfs")
 	cpioRoot = flag.String("cpio", "", "cpio initrd")
 
 	// v allows debug printing.
@@ -124,7 +124,7 @@ func getPort(host, port string) string {
 			p = cp
 		}
 	}
-	if len(p) == 0  {
+	if len(p) == 0 {
 		p = defaultPort
 		verbose("getPort: return default %q", p)
 	}
@@ -174,7 +174,7 @@ func newCPU(host string, args ...string) (retErr error) {
 	if *srvnfs {
 		var fstab string
 		for _, r := range c.Env {
-			if !strings.HasPrefix(r, "CPU_FSTAB=") {
+			if !strings.HasPrefix(r, "CPU_FSTAB=") && !strings.HasPrefix(r, "LC_GLENDA_CPU_FSTAB=") {
 				continue
 			}
 			s := strings.SplitN(r, "=", 2)
@@ -183,7 +183,6 @@ func newCPU(host string, args ...string) (retErr error) {
 			}
 			break
 		}
-		// for now, the cpio is empty, unlike sidecore.
 		f, nfsmount, err := client.SrvNFS(c, *cpioRoot, "/")
 		if err != nil {
 			return err
@@ -196,7 +195,8 @@ func newCPU(host string, args ...string) (retErr error) {
 			// wg.Done()
 		}()
 		verbose("nfsmount %q fstab %q join %q", nfsmount, fstab, client.JoinFSTab(nfsmount, fstab))
-		c.Env = append(c.Env, "CPU_FSTAB="+client.JoinFSTab(nfsmount, fstab))
+		fstab = client.JoinFSTab(nfsmount, fstab)
+		c.Env = append(c.Env, "CPU_FSTAB="+fstab, "LC_GLENDA_CPU_FSTAB="+fstab)
 	}
 
 	go func() {

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -133,7 +133,6 @@ func getPort(host, port string) string {
 }
 
 func newCPU(host string, args ...string) (retErr error) {
-	// note that 9P is enabled if namespace is not empty OR if ninep is true
 	c := client.Command(host, args...)
 	defer func() {
 		verbose("close")

--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -104,16 +104,6 @@ func getKeyFile(host, kf string) string {
 	return kf
 }
 
-// getHostName reads the host name from the config file,
-// if needed. If it is not found, the host name is returned.
-func getHostName(host string) string {
-	h := config.Get(host, "HostName")
-	if len(h) != 0 {
-		host = h
-	}
-	return host
-}
-
 // getPort gets a port.
 func getPort(host, port string) string {
 	p := port
@@ -266,10 +256,9 @@ func main() {
 
 	*keyFile = getKeyFile(host, *keyFile)
 	*port = getPort(host, *port)
-	hn := getHostName(host)
 
-	verbose("connecting to %q port %q", hn, *port)
-	if err := newCPU(hn, a...); err != nil {
+	verbose("connecting to %q port %q", host, *port)
+	if err := newCPU(host, a...); err != nil {
 		e := 1
 		log.Printf("SSH error %s", err)
 		sshErr := &ossh.ExitError{}

--- a/cmds/cpu/doc.go
+++ b/cmds/cpu/doc.go
@@ -5,116 +5,122 @@
 // cpu - connection to CPU server over SSH protocol
 //
 // Synopsis:
-//     cpu [OPTIONS]
+//
+//	cpu [OPTIONS]
 //
 // Advisory:
-//     cpu connects to a remote machine and serves a namespace to it.
-//     That namespace can be a restricted file system (recommended)
-//     or everything up to and including your /.
-//     We do cover a lot of the simpler adversarial attacks, via
-//     private name space mounts and the nonce on the 9p socket, and a
-//     quick review of this code by an expert suggest that on systems
-//     on which your adversary would only be those running at the same
-//     privilege level as you, you may be ok.
 //
-//     You should not use this command to connect to a host that might
-//     have an untrusted, privileged adversary, i.e. someone who might
-//     replace the remote version with a corrupted version, or might
-//     use a different attack to grab the nonce and mount your file
-//     system, changing files before the client cpu exits.
-//.
-//     cpu is best used to connect to a LinuxBoot machine with only one
-//     user, i.e. a non-time-shared machine.
+//	cpu connects to a remote machine and serves a namespace to it.
+//	That namespace can be a restricted file system (recommended)
+//	or everything up to and including your /.
+//	We do cover a lot of the simpler adversarial attacks, via
+//	private name space mounts and the nonce on the 9p socket, and a
+//	quick review of this code by an expert suggest that on systems
+//	on which your adversary would only be those running at the same
+//	privilege level as you, you may be ok.
 //
-//     We are developing a cpu we consider more trustworthy but that is a ways off.
-//     You Have Been Warned :-)
+//	You should not use this command to connect to a host that might
+//	have an untrusted, privileged adversary, i.e. someone who might
+//	replace the remote version with a corrupted version, or might
+//	use a different attack to grab the nonce and mount your file
+//	system, changing files before the client cpu exits.
+//
+// .
+//
+//	cpu is best used to connect to a LinuxBoot machine with only one
+//	user, i.e. a non-time-shared machine.
+//
+//	We are developing a cpu we consider more trustworthy but that is a ways off.
+//	You Have Been Warned :-)
 //
 // Description:
-//     On local machine useful flags are all save -remote
-//     On remote machines, all save dbg9p, key, hostkey.
 //
-//     CPU is an ssh client that starts up a shell on a remote machine,
-//     as usual; but, further, makes a namespace of the local machine
-//     available in a private mount rooted at /tmp/cpu.
-//     Wherever you go, there your files are.
-//     You can, in the ssh session, do something like this:
-//     chroot /tmp/cpu /bin/bash
-//     and at that point, you are running a bash, imported from your local
-//     machine, on the remote machine; it will use your .profile and
-//     all your files are available. You can also do something like
-//     cat /tmp/cpu/etc/hosts
-//     if your host file is lacking; or
-//     cp /etc/hosts /tmp/cpu/tmp
-//     to get the /etc/hosts on the remote machine to your local machine.
+//	On local machine useful flags are all save -remote
+//	On remote machines, all save dbg9p, key, hostkey.
 //
-//     The cpu client makes this work by starting a cpu command on the remote
-//     machine with a -remote switch and several other arguments and
-//     environment variables.
+//	CPU is an ssh client that starts up a shell on a remote machine,
+//	as usual; but, further, makes a namespace of the local machine
+//	available in a private mount rooted at /tmp/cpu.
+//	Wherever you go, there your files are.
+//	You can, in the ssh session, do something like this:
+//	chroot /tmp/cpu /bin/bash
+//	and at that point, you are running a bash, imported from your local
+//	machine, on the remote machine; it will use your .profile and
+//	all your files are available. You can also do something like
+//	cat /tmp/cpu/etc/hosts
+//	if your host file is lacking; or
+//	cp /etc/hosts /tmp/cpu/tmp
+//	to get the /etc/hosts on the remote machine to your local machine.
 //
-//     The local cpu starts a 9p server and, using ssh port forwarding,
-//     makes that server available to the remote. On the remote side, the
-//     cpu command establishes a private, unshared mount of tmpfs on /tmp;
-//     creates /tmp/cpu; and mounts the 9p server on that directory.
+//	The cpu client makes this work by starting a cpu command on the remote
+//	machine with a -remote switch and several other arguments and
+//	environment variables.
 //
-//     CPU has many options, as shown above; most you need not worry about.
-//     The most common invocation is
-//     cpu -h hostname
-//     which will start a shell and mount the 9p server in /tmp/cpu.
-//     Note this mount proceeds over the ssh session, and further
-//     it mounts in a private /tmp; there is little to see when
-//     it is running from outside the ssh session
+//	The local cpu starts a 9p server and, using ssh port forwarding,
+//	makes that server available to the remote. On the remote side, the
+//	cpu command establishes a private, unshared mount of tmpfs on /tmp;
+//	creates /tmp/cpu; and mounts the 9p server on that directory.
+//
+//	CPU has many options, as shown above; most you need not worry about.
+//	The most common invocation is
+//	cpu -h hostname
+//	which will start a shell and mount the 9p server in /tmp/cpu.
+//	Note this mount proceeds over the ssh session, and further
+//	it mounts in a private /tmp; there is little to see when
+//	it is running from outside the ssh session
 //
 // Options:
-//     -9p bool
-//           enable the 9p server in the client (default enabled)
-//           Note that the 9p server is also enabled if the namespace
-//           is not empty. To ensure the 9p server is not set,
-//           cpu -9p=f -namespace=""
-//     -d
-//           enable debug prints
-//     -dbg9p
-//           show 9p io
-//     -dump
-//           Dump all debug output and 9p packets to a file in /tmp
-//     -hk string
-//           host key file
-//     -key string
-//           key file (default "$HOME/.ssh/cpu_rsa")
-//     -mountopts string
-//           extra options for the 9p mount, default "". Lightly tested.
-//     -msize uint
-//           max size for 9p packets, default 1 MiB
-//     -namespace string
-//           namespace defines the bind mounts that are done by cpud.
-//           The format is of a : separated string, in the style of PATH
-//           variables, with one addition: one can define where on the
-//           host the bind is done.
-//           The default is /lib:/lib64:/usr:/bin:/etc:/home, which means
-//           these directories will be provided by the 9p server in the
-//           client. Sometimes, it is useful to be able to remap the names.
-//           On OSX, for example, /Users/rob would be rob's home directory,
-//           but we might want it to appears as /home/rob on Linux.
-//           This change is accomplished with
-//           -namespace /lib:/lib64:/usr:/bin:/etc:/home/rob=/Users/rob
-//     -network string
-//           network to use (default "tcp")
-//     -port9p string
-//           port9p # on remote machine for 9p mount
-//     -remote
-//           Indicates we are the remote side of the cpu session
-//     -root
-//           Root for 9p server, default "/"
-//           If you are cpu'ing from, eg., x86 to arm, you might
-//           use, e.g., /amd64
-//     -sp string
-//          remote port, default 17010
-//     -srv string
-//           what server to run (default none; use internal)
-//     -timeout9p time.Duration
-//           How long to wait for the server to connect to 9p (default100ms)
+//
+//	-9p bool
+//	      enable the 9p server in the client (default enabled)
+//	      Note that the 9p server is also enabled if the namespace
+//	      is not empty. To ensure the 9p server is not set,
+//	      cpu -9p=f -namespace=""
+//	-d
+//	      enable debug prints
+//	-dbg9p
+//	      show 9p io
+//	-dump
+//	      Dump all debug output and 9p packets to a file in /tmp
+//	-hk string
+//	      host key file
+//	-key string
+//	      key file (default "$HOME/.ssh/cpu_rsa")
+//	-mountopts string
+//	      extra options for the 9p mount, default "". Lightly tested.
+//	-msize uint
+//	      max size for 9p packets, default 1 MiB
+//	-namespace string
+//	      namespace defines the bind mounts that are done by cpud.
+//	      The format is of a : separated string, in the style of PATH
+//	      variables, with one addition: one can define where on the
+//	      host the bind is done.
+//	      The default is /lib:/lib64:/usr:/bin:/etc:/home, which means
+//	      these directories will be provided by the 9p server in the
+//	      client. Sometimes, it is useful to be able to remap the names.
+//	      On OSX, for example, /Users/rob would be rob's home directory,
+//	      but we might want it to appears as /home/rob on Linux.
+//	      This change is accomplished with
+//	      -namespace /lib:/lib64:/usr:/bin:/etc:/home/rob=/Users/rob
+//	-network string
+//	      network to use (default "tcp")
+//	-port9p string
+//	      port9p # on remote machine for 9p mount
+//	-remote
+//	      Indicates we are the remote side of the cpu session
+//	-root
+//	      Root for 9p server, default "/"
+//	      If you are cpu'ing from, eg., x86 to arm, you might
+//	      use, e.g., /amd64
+//	-sp string
+//	     remote port, default 17010
+//	-srv string
+//	      what server to run (default none; use internal)
+//	-timeout9p time.Duration
+//	      How long to wait for the server to connect to 9p (default100ms)
 //
 // Cpud environment variables:
-//     - CPUD_IGNORE_CMD_ERROR: passed from cpud to cpud --remote.  If the
+//   - CPUD_IGNORE_CMD_ERROR: passed from cpud to cpud --remote.  If the
 //     command executed by cpud returns an error code, ignore it.  This is
 //     useful if we are running an interactive shell.
 //
@@ -132,58 +138,61 @@
 // We can turn these off at some point but for now, in early days, we may want them.
 // Note that these messages come from the remote side.
 // cpu to a machine with bash as your shell and run a command
-//   cpu -sp 17010 date
-//     2019/05/17 16:53:22 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
-//     2019/05/17 16:53:22 Mounted /tmp/cpu/lib on /lib
-//     2019/05/17 16:53:22 Mounted /tmp/cpu/lib64 on /lib64
-//     2019/05/17 16:53:22 Warning: mounting /tmp/cpu/lib32 on /lib32 failed: no such file or directory
-//     2019/05/17 16:53:22 Mounted /tmp/cpu/usr on /usr
-//     2019/05/17 16:53:22 Mounted /tmp/cpu/bin on /bin
-//     2019/05/17 16:53:22 Mounted /tmp/cpu/etc on /etc
-//     Fri May 17 16:53:23 UTC 2019
+//
+//	cpu -sp 17010 date
+//	  2019/05/17 16:53:22 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
+//	  2019/05/17 16:53:22 Mounted /tmp/cpu/lib on /lib
+//	  2019/05/17 16:53:22 Mounted /tmp/cpu/lib64 on /lib64
+//	  2019/05/17 16:53:22 Warning: mounting /tmp/cpu/lib32 on /lib32 failed: no such file or directory
+//	  2019/05/17 16:53:22 Mounted /tmp/cpu/usr on /usr
+//	  2019/05/17 16:53:22 Mounted /tmp/cpu/bin on /bin
+//	  2019/05/17 16:53:22 Mounted /tmp/cpu/etc on /etc
+//	  Fri May 17 16:53:23 UTC 2019
+//
 // cpu to a machine and run $SHELL (since no arguments were given)
 // NOTE: $SHELL is NOT installed on the remote machine! It (and all its .so's and . files)
 // come from the local machine.
 // cpu sp -17010
-//    2019/05/17 16:58:04 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
-//    2019/05/17 16:58:04 Mounted /tmp/cpu/lib on /lib
-//    2019/05/17 16:58:04 Mounted /tmp/cpu/lib64 on /lib64
-//    2019/05/17 16:58:04 Warning: mounting /tmp/cpu/lib32 on /lib32 failed: no such file or directory
-//    2019/05/17 16:58:04 Mounted /tmp/cpu/usr on /usr
-//    2019/05/17 16:58:04 Mounted /tmp/cpu/bin on /bin
-//    2019/05/17 16:58:05 Mounted /tmp/cpu/etc on /etc
-//    root@(none):/# echo ~
-//    /tmp/cpu/home/rminnich
-//    root@(none):/# ls ~
-//    IDAPROPASSWORD  go      ida-7.2  projects            salishan2019random~
-//    bin             gopath  papers   salishan2019random  snap
-//    root@(none):/#
-//    # Now that we are on the node, modprobe something
-//    root@(none):/# depmod
-//    depmod: ERROR: could not open directory /lib/modules/5.0.0-rc3+: No such file or directory
-//    depmod: FATAL: could not search modules: No such file or directory
-//    root@(none):/#
-//    # Note that, if we had the right modules on our LOCAL machine for this remote machine, we could
-//    # insert them. This further means you can build a modular kernel in FLASH and insmod needed modules
-//    # later (as long as your core kernel has networking, that is!). Modules could include, e.g., an AHCI
-//    # driver.
-//    # run the lspci command but redirect output to ~
-//    # note it is not installed on the remote machine; it comes from our local machine.
-//    root@(none):/# lspci
-//    00:00.0 Host bridge: Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
-//    00:01.0 VGA compatible controller: Device 1234:1111 (rev 02)
-//    00:02.0 Unclassified device [00ff]: Red Hat, Inc. Virtio RNG
-//    00:03.0 Ethernet controller: Intel Corporation 82540EM Gigabit Ethernet Controller (rev 03)
-//    00:1f.0 ISA bridge: Intel Corporation 82801IB (ICH9) LPC Interface Controller (rev 02)
-//    00:1f.2 SATA controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode] (rev 02)
-//    00:1f.3 SMBus: Intel Corporation 82801I (ICH9 Family) SMBus Controller (rev 02)
-//    root@(none):/# lspci > ~/xyz
-//    root@(none):/# exit
-//    # exit and notice that file is on my local machine now:
-//    exit
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/xcmds/cpu$ ls -l ~/xyz
-//    -rw-r--r-- 1 rminnich rminnich 577 May 17 17:06 /home/rminnich/xyz
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/xcmds/cpu$
+//
+//	2019/05/17 16:58:04 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
+//	2019/05/17 16:58:04 Mounted /tmp/cpu/lib on /lib
+//	2019/05/17 16:58:04 Mounted /tmp/cpu/lib64 on /lib64
+//	2019/05/17 16:58:04 Warning: mounting /tmp/cpu/lib32 on /lib32 failed: no such file or directory
+//	2019/05/17 16:58:04 Mounted /tmp/cpu/usr on /usr
+//	2019/05/17 16:58:04 Mounted /tmp/cpu/bin on /bin
+//	2019/05/17 16:58:05 Mounted /tmp/cpu/etc on /etc
+//	root@(none):/# echo ~
+//	/tmp/cpu/home/rminnich
+//	root@(none):/# ls ~
+//	IDAPROPASSWORD  go      ida-7.2  projects            salishan2019random~
+//	bin             gopath  papers   salishan2019random  snap
+//	root@(none):/#
+//	# Now that we are on the node, modprobe something
+//	root@(none):/# depmod
+//	depmod: ERROR: could not open directory /lib/modules/5.0.0-rc3+: No such file or directory
+//	depmod: FATAL: could not search modules: No such file or directory
+//	root@(none):/#
+//	# Note that, if we had the right modules on our LOCAL machine for this remote machine, we could
+//	# insert them. This further means you can build a modular kernel in FLASH and insmod needed modules
+//	# later (as long as your core kernel has networking, that is!). Modules could include, e.g., an AHCI
+//	# driver.
+//	# run the lspci command but redirect output to ~
+//	# note it is not installed on the remote machine; it comes from our local machine.
+//	root@(none):/# lspci
+//	00:00.0 Host bridge: Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
+//	00:01.0 VGA compatible controller: Device 1234:1111 (rev 02)
+//	00:02.0 Unclassified device [00ff]: Red Hat, Inc. Virtio RNG
+//	00:03.0 Ethernet controller: Intel Corporation 82540EM Gigabit Ethernet Controller (rev 03)
+//	00:1f.0 ISA bridge: Intel Corporation 82801IB (ICH9) LPC Interface Controller (rev 02)
+//	00:1f.2 SATA controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode] (rev 02)
+//	00:1f.3 SMBus: Intel Corporation 82801I (ICH9 Family) SMBus Controller (rev 02)
+//	root@(none):/# lspci > ~/xyz
+//	root@(none):/# exit
+//	# exit and notice that file is on my local machine now:
+//	exit
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/xcmds/cpu$ ls -l ~/xyz
+//	-rw-r--r-- 1 rminnich rminnich 577 May 17 17:06 /home/rminnich/xyz
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/xcmds/cpu$
 //
 // A note on sizes of things. We can get an image down to 3 MiB if the only
 // binary is cpu. See github.com:linuxboot/mainboards/aeeon/up for an example.

--- a/cmds/cpu/doc.go
+++ b/cmds/cpu/doc.go
@@ -254,4 +254,11 @@
 // If you want to learn more read the factotum paper by Grosse et. al. and the original
 // Plan 9 papers on cpu, but be aware there are many subtle details visible only
 // in code.
+//
+// You can now tentatively talk to standard sshd.
+// Here is an example:
+// ./cpu -nfs=true -9p=false -d -key ~/.ssh/homemac -sp 22 127.0.0.1
+// A few things: 9p has to be off, since sshd don't understand the -9 switch
+// Failing to Setenv is no longer an error, so you may not be able to set things
+// like SHELL.
 package main

--- a/cmds/cpud/main_mdns_linux.go
+++ b/cmds/cpud/main_mdns_linux.go
@@ -59,7 +59,7 @@ func servemDNS(s *ssh.Server) error {
 	if err != nil {
 		return fmt.Errorf("Could not advertise with dns-sd: %w", err)
 	}
-//	defer ds.Unregister()
+	//	defer ds.Unregister()
 
 	wrap := &handleWrapper{
 		handle: s.Handler,

--- a/cmds/cpuns/main_linux.go
+++ b/cmds/cpuns/main_linux.go
@@ -52,7 +52,7 @@ func checkprivate() error {
 		return err
 	}
 	if len(mnts) != 1 {
-		return fmt.Errorf("got more than 1 mount for /(%v):%v", mnts, os.ErrInvalid)
+		return fmt.Errorf("got more than 1 mount for /(%v):%w", mnts, os.ErrInvalid)
 	}
 	entry := mnts[0]
 	isShared := strings.Contains(entry.Optional, "shared:1")

--- a/cmds/cpuns/main_linux.go
+++ b/cmds/cpuns/main_linux.go
@@ -67,7 +67,7 @@ func sudoUnshareCpunfs(env string, args ...string) error {
 		c.Env = append(c.Env, "CPU_FSTAB="+fstab)
 		v("extended c.Env: %v", c.Env)
 	}
-	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	c.Stdin, c.Stdout, c.Stderr, c.Dir = os.Stdin, os.Stdout, os.Stderr, os.Getenv("PWD")
 	v("Run %q", c)
 	return c.Run()
 }
@@ -76,10 +76,6 @@ func sudoUnshareCpunfs(env string, args ...string) error {
 // of a fork bomb. Such bombs rarely if ever take systems down any
 // more anyway ...
 func main() {
-	fmt.Printf("uid %v git %v", os.Getuid(), os.Getgid())
-	if err := checkprivate(); err != nil {
-		log.Fatal(err)
-	}
 	flag.CommandLine = flag.NewFlagSet("cpuns", flag.ExitOnError)
 	debug := flag.Bool("d", false, "enable debug prints")
 	env := flag.String("env", "", "newline-separated array of environment variables")

--- a/cmds/cpuns/main_linux.go
+++ b/cmds/cpuns/main_linux.go
@@ -1,0 +1,107 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/moby/sys/mountinfo"
+	"github.com/u-root/cpu/session"
+)
+
+var (
+	// v allows debug printing.
+	// Do not call it directly, call verbose instead.
+	v = func(string, ...interface{}) {}
+)
+
+func verbose(f string, a ...interface{}) {
+	v("CPUNS:"+f, a...)
+}
+
+func checkprivate() error {
+	mnts, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter("/"))
+	if err != nil {
+		return err
+	}
+	if len(mnts) != 1 {
+		return fmt.Errorf("got more than 1 mount for /(%v):%v", mnts, os.ErrInvalid)
+	}
+	entry := mnts[0]
+	fmt.Printf("Optional is %q\n", entry.Optional)
+	isShared := strings.Contains(entry.Optional, "shared:1")
+	if isShared {
+		return fmt.Errorf("/ is not private")
+	}
+	return nil
+}
+
+func main() {
+	fmt.Printf("uid %v git %v", os.Getuid(), os.Getgid())
+	if err := checkprivate(); err != nil {
+		log.Fatal(err)
+	}
+	flag.CommandLine = flag.NewFlagSet("cpuns", flag.ExitOnError)
+	debug := flag.Bool("d", false, "enable debug prints")
+	flag.Parse()
+	if *debug {
+		v = log.Printf
+		session.SetVerbose(v)
+	}
+	args := flag.Args()
+	shell := "/bin/sh"
+	if len(args) == 0 {
+		sh, ok := os.LookupEnv("SHELL")
+		if ok {
+			shell = sh
+		}
+		args = []string{shell}
+	}
+
+	// Can not set the first arg (port9p) since there is no
+	// good way to pass it (it is passed as as switch in cpud).
+	// That is ok, 9p has never been that good on Linux.
+	s := session.New("", args[0], args[1:]...)
+	if err := s.NameSpace(); err != nil {
+		log.Fatalf("CPUD(remote): %v", err)
+	}
+
+	if err := s.Terminal(); err != nil {
+		log.Printf("s.Terminal failed(%v); continuing anyway", err)
+	}
+
+	u, ok := os.LookupEnv("SUDO_UID")
+	if !ok {
+		log.Printf("no SUDO_UID; continuing anyway")
+	}
+	g, ok := os.LookupEnv("SUDO_GID")
+	if !ok {
+		log.Printf("no SUDO_GID; continuing anyway")
+	}
+
+	uid, err := strconv.Atoi(u)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	gid, err := strconv.Atoi(g)
+	if err != nil {
+		log.Fatal(err)
+	}
+	c := s.Command()
+	c.Stdin, c.Stdout, c.Stderr = s.Stdin, s.Stdout, s.Stderr
+	c.SysProcAttr = &syscall.SysProcAttr{}
+	c.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
+	if err := c.Run(); err != nil {
+		log.Fatalf("Run %v returns %v", c, err)
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.1-0.20240514075308-8f1b719cb6a2
 	github.com/google/uuid v1.5.0
 	github.com/mdlayher/vsock v1.2.1
+	github.com/moby/sys/mountinfo v0.7.1
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/willscott/go-nfs v0.0.2
 	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/mdlayher/vsock v1.2.1 h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ=
 github.com/mdlayher/vsock v1.2.1/go.mod h1:NRfCibel++DgeMD8z/hP+PPTjlNJsdPOmxcnENvE+SE=
 github.com/miekg/dns v1.1.55 h1:GoQ4hpsj0nFLYe+bWiCToyrBEJXkQfOOIvFGFy0lEgo=
 github.com/miekg/dns v1.1.55/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
+github.com/moby/sys/mountinfo v0.7.1 h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g=
+github.com/moby/sys/mountinfo v0.7.1/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
@@ -96,6 +98,7 @@ golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/session/doc.go
+++ b/session/doc.go
@@ -13,9 +13,9 @@
 // needed and will set one up.
 //
 // Run will also set up a process namespace via 9p and other mounts,
-// if needed. If CPU_FSTAB is set, it
+// if needed. If LC_GLENDA_CPU_FSTAB or CPU_FSTAB is set, it
 // is assumed to be a string in fstab(5) format and Run will mount the
-// specified file systems. CPU_FSTAB is most often used for virtiofs
+// specified file systems. *CPU_FSTAB is most often used for virtiofs
 // mounts from virtual machines.
 //
 // For the moment, servers only call Run(), which

--- a/session/fns.go
+++ b/session/fns.go
@@ -16,7 +16,7 @@ func verbose(f string, a ...interface{}) {
 	v("session:"+f, a...)
 }
 
-func runCmd(c *exec.Cmd) error {
+func RunCmd(c *exec.Cmd) error {
 	sigChan := make(chan os.Signal, 1)
 	defer close(sigChan)
 	signal.Notify(sigChan, unix.SIGTERM, unix.SIGINT)

--- a/session/session.go
+++ b/session/session.go
@@ -69,7 +69,7 @@ func (s *Session) DropPrivs() error {
 	uid := unix.Getuid()
 	verbose("dropPrives: uid is %v", uid)
 	if uid == 0 {
-		verbose("dropPrivs: not dropping privs")
+		verbose("dropPrivs: uid is 0: not dropping privs")
 		return nil
 	}
 	gid := unix.Getgid()
@@ -206,10 +206,10 @@ func (s *Session) Run() error {
 	c.Stdin, c.Stdout, c.Stderr, c.Dir = s.Stdin, s.Stdout, s.Stderr, os.Getenv("PWD")
 	dirInfo, err := os.Stat(c.Dir)
 	if err != nil || !dirInfo.IsDir() {
-		log.Printf("CPUD: your $PWD %s is not in the remote namespace", c.Dir)
+		log.Printf("CPUD: your $PWD %q is not in the remote namespace", c.Dir)
 		return os.ErrNotExist
 	}
-	err = runCmd(c)
+	err = RunCmd(c)
 	verbose("Run %v returns %v", c, err)
 	if err != nil {
 		if s.fail && len(wtf) != 0 {
@@ -236,4 +236,61 @@ func New(port9p, cmd string, args ...string) *Session {
 	// The 9P designers had the wisdom to make msize negotiation part of session initiation,
 	// so we had a way out!
 	return &Session{msize: 64 * 1024, Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr, port9p: port9p, cmd: cmd, args: args}
+}
+
+// The following two functions were set up for cpuns.
+// They provide a bit more flexibility in setting things
+// up until we can agree on how it should all work.
+// Side note: it's probably time to remove all the
+// wtf support, above; it has been years since we needed it.
+// Run starts up a remote cpu session. It is started by a cpu
+// daemon via a -remote switch.
+
+// NameSpace prepares the namespace for the session.
+func (s *Session) NameSpace() error {
+	var errs error
+
+	if err := runSetup(); err != nil {
+		return err
+	}
+	if err := s.TmpMounts(); err != nil {
+		verbose("TmpMounts error: %v", err)
+		s.fail = true
+		errs = errors.Join(errs, err)
+	}
+
+	verbose("call s.NameSpace")
+	err := s.Namespace()
+	if err != nil {
+		return errors.Join(errs, fmt.Errorf("CPUD:Namespace: %v", err))
+	}
+
+	// The CPU_FSTAB environment variable is, literally, an fstab.
+	// Why an environment variable and not a file? We do not
+	// want to require any 9p mounts at all. People should be able
+	// to do this:
+	// CPU_FSTAB=`cat fstab`
+	// and get the mounts they want. The first uses of this will
+	// be building namespaces with drive and virtiofs.
+
+	// In some cases if you set LD_LIBRARY_PATH it is ignored.
+	// This is disappointing to say the least. We just bind a few things into /
+	// bind *may* hide local resources but for now it's the least worst option.
+	if tab, ok := os.LookupEnv("CPU_FSTAB"); ok {
+		verbose("Mounting %q", tab)
+		if err := mount.Mount(tab); err != nil {
+			verbose("fstab mount failure: %v", err)
+			// Should we die if the mounts fail? For now, we think not;
+			// the user may be able to debug. Just record that it failed.
+			s.fail = true
+		}
+	}
+
+	return nil
+}
+
+// Command returns an exec.Command that users can additionally modify.
+// This will all certainly change.
+func (s *Session) Command() *exec.Cmd {
+	return exec.Command(s.cmd, s.args...)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -154,12 +154,7 @@ func (s *Session) Run() error {
 		return errors.Join(errs, fmt.Errorf("CPUD:Namespace: %v", err))
 	}
 
-	// There are two environment variables containing and fstab:
-	// CPU_FSTAB, the original, when cpu did not work with sshd
-	// LC_GLENDA_CPU_FSTAB, for communicating to sshd, which generally
-	//   strip all environment variables not starting with LC_
-	//   (a questionable decision, but one we can not change).
-	// The *CPU_FSTAB environment variable is, literally, an fstab.
+	// The CPU_FSTAB environment variable is, literally, an fstab.
 	// Why an environment variable and not a file? We do not
 	// want to require any 9p mounts at all. People should be able
 	// to do this:
@@ -170,7 +165,7 @@ func (s *Session) Run() error {
 	// In some cases if you set LD_LIBRARY_PATH it is ignored.
 	// This is disappointing to say the least. We just bind a few things into /
 	// bind *may* hide local resources but for now it's the least worst option.
-	for _, fstab := range []string{"CPU_FSTAB", "LC_GLENDA_CPU_FSTAB"} {
+	for _, fstab := range []string{"CPU_FSTAB"} {
 		if tab, ok := os.LookupEnv(fstab); ok {
 			verbose("Mounting %q", tab)
 			if err := mount.Mount(tab); err != nil {
@@ -272,12 +267,7 @@ func (s *Session) NameSpace() error {
 		return errors.Join(errs, fmt.Errorf("CPUD:Namespace: %v", err))
 	}
 
-	// There are two environment variables containing and fstab:
-	// CPU_FSTAB, the original, when cpu did not work with sshd
-	// LC_GLENDA_CPU_FSTAB, for communicating to sshd, which generally
-	//   strip all environment variables not starting with LC_
-	//   (a questionable decision, but one we can not change).
-	// The *CPU_FSTAB environment variable is, literally, an fstab.
+	// The CPU_FSTAB environment variable is, literally, an fstab.
 	// Why an environment variable and not a file? We do not
 	// want to require any 9p mounts at all. People should be able
 	// to do this:

--- a/session/session.go
+++ b/session/session.go
@@ -154,7 +154,12 @@ func (s *Session) Run() error {
 		return errors.Join(errs, fmt.Errorf("CPUD:Namespace: %v", err))
 	}
 
-	// The CPU_FSTAB environment variable is, literally, an fstab.
+	// There are two environment variables containing and fstab:
+	// CPU_FSTAB, the original, when cpu did not work with sshd
+	// LC_GLENDA_CPU_FSTAB, for communicating to sshd, which generally
+	//   strip all environment variables not starting with LC_
+	//   (a questionable decision, but one we can not change).
+	// The *CPU_FSTAB environment variable is, literally, an fstab.
 	// Why an environment variable and not a file? We do not
 	// want to require any 9p mounts at all. People should be able
 	// to do this:
@@ -165,13 +170,15 @@ func (s *Session) Run() error {
 	// In some cases if you set LD_LIBRARY_PATH it is ignored.
 	// This is disappointing to say the least. We just bind a few things into /
 	// bind *may* hide local resources but for now it's the least worst option.
-	if tab, ok := os.LookupEnv("CPU_FSTAB"); ok {
-		verbose("Mounting %q", tab)
-		if err := mount.Mount(tab); err != nil {
-			verbose("fstab mount failure: %v", err)
-			// Should we die if the mounts fail? For now, we think not;
-			// the user may be able to debug. Just record that it failed.
-			s.fail = true
+	for _, fstab := range []string{"CPU_FSTAB", "LC_GLENDA_CPU_FSTAB"} {
+		if tab, ok := os.LookupEnv(fstab); ok {
+			verbose("Mounting %q", tab)
+			if err := mount.Mount(tab); err != nil {
+				verbose("fstab mount failure: %v", err)
+				// Should we die if the mounts fail? For now, we think not;
+				// the user may be able to debug. Just record that it failed.
+				s.fail = true
+			}
 		}
 	}
 
@@ -265,7 +272,12 @@ func (s *Session) NameSpace() error {
 		return errors.Join(errs, fmt.Errorf("CPUD:Namespace: %v", err))
 	}
 
-	// The CPU_FSTAB environment variable is, literally, an fstab.
+	// There are two environment variables containing and fstab:
+	// CPU_FSTAB, the original, when cpu did not work with sshd
+	// LC_GLENDA_CPU_FSTAB, for communicating to sshd, which generally
+	//   strip all environment variables not starting with LC_
+	//   (a questionable decision, but one we can not change).
+	// The *CPU_FSTAB environment variable is, literally, an fstab.
 	// Why an environment variable and not a file? We do not
 	// want to require any 9p mounts at all. People should be able
 	// to do this:


### PR DESCRIPTION
Did you want to run cpu, but don't want to set up cpud?
If you have an sshd, you're good to gol

This is cpu talking to an sshd.
```
rminnich@pop-os:~/go/src/github.com/u-root/cpu/cmds/cpu$ cpu -nfs=true -9p=false  q date
Wed Jul 10 03:08:16 PM PDT 2024
```

This is cpu talking to an sshd, but setting up the namespace.
```
rminnich@pop-os:~/go/src/github.com/u-root/cpu/cmds/cpu$ cpu -nfs=true -9p=false  q ~/bin/ns
[sudo] password for rminnich:
rminnich@pop-os:~$ mount
...
127.0.0.1:9973ecb0-b836-4f7b-997d-d7bc7dc08456 on /tmp/cpu type nfs (rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,nolock,proto=tcp,port=44957,timeo=600,retrans=2,sec=sys,mountaddr=127.0.0.1,mountvers=3,mountport=44957,mountproto=tcp,local_lock=all,addr=127.0.0.1)
127.0.0.1:9973ecb0-b836-4f7b-997d-d7bc7dc08456/usr/lib on /usr/lib type nfs (rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,nolock,proto=tcp,port=44957,timeo=600,retrans=2,sec=sys,mountaddr=127.0.0.1,mountvers=3,mountport=44957,mountproto=tcp,local_lock=all,addr=127.0.0.1)

...
```

ns is a script:
```
#!/bin/sh

sudo -E unshare -m ~rminnich/go/bin/cpuns
```

So the key new command here is cpuns.

So, if you want cpu, with just a plain old sshd, you've got it now.

There are a few issues left, but if you want early access, here it is.

I don't even know how to debug it ...