### PR TITLE
cpud: print fstab mount errors

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -169,7 +169,7 @@ func (s *Session) Run() error {
 		if tab, ok := os.LookupEnv(fstab); ok {
 			verbose("Mounting %q", tab)
 			if err := mount.Mount(tab); err != nil {
-				verbose("fstab mount failure: %v", err)
+				log.Printf("fstab mount failure: %v", err)
 				// Should we die if the mounts fail? For now, we think not;
 				// the user may be able to debug. Just record that it failed.
 				s.fail = true


### PR DESCRIPTION
In most cases when we get an error "CPUD: your $PWD is not in the remote namespace", it is due to some missing mounts, for example, a mount target dir does not exist on the remote machine. Printing out the mount errors helps debugging.