### PR TITLE
docs: update link to linuxboot cpu docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/u-root/cpu/blob/master/LICENSE)
 
 This repo is an implementation the Plan 9 cpu command, both client and server, for Linux.
-More detail is available in the [CPU chapter of the LinuxBoot book](https://book.linuxboot.org/cpu/).
+More detail is available in the [CPU chapter of the LinuxBoot book](https://book.linuxboot.org/utilities/cpu.html).
 Unlike the Plan 9 command, this version uses the ssh protocol for the underlying transport. It includes
 features familiar to ssh users, such as support for the ssh config file.
 

--- a/p9cpu/README.md
+++ b/p9cpu/README.md
@@ -2,7 +2,7 @@
 
 `p9cpu` is an implementation of the Plan 9 `cpu` command for Linux, similar to
 [u-root/cpu](https://github.com/u-root/cpu). Check the
-[CPU chapter of the LinuxBoot book](https://book.linuxboot.org/cpu/) for more
+[CPU chapter of the LinuxBoot book](https://book.linuxboot.org/utilities/cpu.html) for more
 details. Compared with the original Plan 9 `cpu` and the Go version
 [u-root/cpu](https://github.com/u-root/cpu), `p9cpu` is written in Rust and
 based on [tokio](https://tokio.rs/). It uses gRPC for the underlying transport.


### PR DESCRIPTION
Update dead link for `cpu` command docs.