### PR TITLE
For convenience, if nfs is enabled, ninep should be disabled

### DIFF
--- a/cmds/cpu/cpu.go
+++ b/cmds/cpu/cpu.go
@@ -305,6 +305,9 @@ func main() {
 	if *port == "22" {
 		*sshd = true
 	}
+	if *srvnfs {
+		*ninep = false
+	}
 	verbose("connecting to %q port %q", host, *port)
 	if err := newCPU(host, a...); err != nil {
 		e := 1


### PR DESCRIPTION
We just hit this, for the first time, on a system that did not, and never would, have 9p.