### PR TITLE
cpud: clear CPU_FSTAB and LC_GLENDA_CPU_FSTAB before starting command

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -204,6 +204,12 @@ func (s *Session) Run() error {
 	// worry about unmounting them once the command is done: the
 	// unmount happens for free since we unshared.
 	verbose("runRemote: command is %q", s.args)
+
+	// Do not propagate CPU_FSTAB, it causes trouble
+	// if you cpu to a machine and just run cpu.
+	os.Unsetenv("CPU_FSTAB")
+	os.Unsetenv("LC_GLENDA_CPU_FSTAB")
+
 	c := exec.Command(s.cmd, s.args...)
 	c.Stdin, c.Stdout, c.Stderr, c.Dir = s.Stdin, s.Stdout, s.Stderr, os.Getenv("PWD")
 	dirInfo, err := os.Stat(c.Dir)
@@ -287,6 +293,11 @@ func (s *Session) NameSpace() error {
 			s.fail = true
 		}
 	}
+
+	// Do not propagate CPU_FSTAB, it causes trouble
+	// if you cpu to a machine and just run cpu.
+	os.Unsetenv("CPU_FSTAB")
+	os.Unsetenv("LC_GLENDA_CPU_FSTAB")
 
 	return nil
 }


### PR DESCRIPTION
If you cpu to a machine, and the only command you run is cpu, the CPU_FSTAB and LC_GLENDA_CPU_FSTAB variables must be cleared, else the cpu will inherit them and assume it should use them.

Before starting the command, os.Unsetenv CPU_FSTAB and LC_GLENDA_CPU_FSTAB.

It's changed in both the old code and the new code cpuns uses.

I still have to try to figure out a test.

But, now, on osx, I can cpu into a docker container for a risc-v board, and from that container cpu into the board.

This is very, very nice. It gets around the problem that docker containers on osx can not do volume mapping: cpu alone, on osx, has value in and of itself.