### PR TITLE
CI: cosign --yes, remove COSIGN_EXPERIMENTAL

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,8 +91,6 @@ jobs:
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
The CLI behavior has change since. It now prompts for a 'yes'.
Adapted via a look at https://github.com/sigstore/cosign-installer
Regarding COSIGN_EXPERIMENTAL:
https://blog.sigstore.dev/cosign-2-0-released/

Signed-off-by: Daniel Maslowski <info@orangecms.org>
