### PR TITLE
Enable verbose printing during go generate

### DIFF
--- a/vm/build.go
+++ b/vm/build.go
@@ -66,6 +66,8 @@ var builds = []build{
 }
 
 func main() {
+	_, verbose := os.LookupEnv("VM_VERBOSE")
+
 	env := []string{"CGO_ENABLED=0"}
 	for _, b := range builds {
 		log.Printf("Build %v", b)
@@ -130,7 +132,7 @@ func main() {
 		if len(b.container) == 0 {
 			continue
 		}
-		if false {
+		if verbose {
 			ref, err := name.ParseReference(b.container, name.Insecure)
 			if err != nil {
 				log.Fatal(err)
@@ -138,7 +140,6 @@ func main() {
 
 			fmt.Printf("parse %s to %s", b.container, ref.Name())
 		}
-		//img, err := crane.Pull(ref.Name())
 		img, err := crane.Pull(b.container)
 		if err != nil {
 			log.Fatal(err)

--- a/vm/ip_linux_test.go
+++ b/vm/ip_linux_test.go
@@ -42,6 +42,7 @@ func none(s string, t []string) bool {
 // TestIP tests creation and removal of addresses, tunnels, and
 // ARP entries with the u-root ip command.
 func TestIP(t *testing.T) {
+	_, spew := os.LookupEnv("VMTEST_SPEW")
 	d := t.TempDir()
 	for _, arch := range []string{"amd64", "arm", "arm64", "riscv64"} {
 		i, err := vm.New("linux", arch)
@@ -66,7 +67,7 @@ func TestIP(t *testing.T) {
 
 		// For debug. It's been needed, but we do not want this spew in
 		// CI logs, so leave it off.
-		if false {
+		if spew {
 			c.Stdout, c.Stderr = os.Stdout, os.Stderr
 		}
 		if err := i.StartVM(c); err != nil {
@@ -206,13 +207,13 @@ func TestIP(t *testing.T) {
 					t.Errorf("CPUCommand: got %v, want nil", err)
 					continue
 				}
-				if false {
+				if spew {
 					client.SetVerbose(t.Logf)
 				}
 
 				b, err := cpu.CombinedOutput()
 
-				if false { // Only enable this if you want to see console output/errors.
+				if spew { // Only enable this if you want to see console output/errors.
 					t.Logf("%s %v", string(b), err)
 				}
 


### PR DESCRIPTION
You can not pass flags directly, but
export VM_VERBOSE=1
go generate

will get your more output