### PR TITLE
remove errors.Is in tests

### DIFF
--- a/vm/initramfs_linux_test.go
+++ b/vm/initramfs_linux_test.go
@@ -19,7 +19,7 @@ func TestInitRamfs(t *testing.T) {
 	}
 
 	b, err := vm.New("linux", "amd64")
-	if !errors.Is(err, nil) {
+	if err != nil {
 		t.Fatalf("Testing kernel=linux arch=amd64: got %v, want nil", err)
 	}
 

--- a/vm/vm_linux_test.go
+++ b/vm/vm_linux_test.go
@@ -8,7 +8,6 @@ package vm_test
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,7 +22,7 @@ import (
 func TestCPUAMD64(t *testing.T) {
 	d := t.TempDir()
 	i, err := vm.New("linux", "amd64")
-	if !errors.Is(err, nil) {
+	if err != nil {
 		t.Fatalf("Testing kernel=linux arch=amd64: got %v, want nil", err)
 	}
 
@@ -58,7 +57,7 @@ func TestCPUAMD64(t *testing.T) {
 		{cmd: "/bbin/dd", args: []string{"if=/tmp/cpu/a", "of=/tmp/cpu/b"}, ok: true},
 	} {
 		cpu, err := i.CPUCommand(tt.cmd, tt.args...)
-		if !errors.Is(err, nil) {
+		if err != nil {
 			t.Errorf("CPUCommand: got %v, want nil", err)
 			continue
 		}
@@ -110,7 +109,7 @@ func TestCPUAMD64(t *testing.T) {
 func TestCPUARM(t *testing.T) {
 	d := t.TempDir()
 	i, err := vm.New("linux", "arm")
-	if !errors.Is(err, nil) {
+	if err != nil {
 		t.Fatalf("Testing kernel=linux arch=arm: got %v, want nil", err)
 	}
 
@@ -146,7 +145,7 @@ func TestCPUARM(t *testing.T) {
 		{cmd: "/bbin/dd", args: []string{"if=/tmp/cpu/a", "of=/tmp/cpu/b"}, ok: true},
 	} {
 		cpu, err := i.CPUCommand(tt.cmd, tt.args...)
-		if !errors.Is(err, nil) {
+		if err != nil {
 			t.Errorf("CPUCommand: got %v, want nil", err)
 			continue
 		}


### PR DESCRIPTION
errors.Is(err, nil) is needed, in some places, but not here.

Sometimes packages return error wrapping nil, but not in this case.

But, see:
https://go.dev/play/p/yjBlsllddSE

Gemini confidently predicts that the code in the Playground is wrong. Oops. Thanks to brho for that test.