### PR TITLE
Add a systemd for embedded systems with one user

### DIFF
--- a/systemd/Makefile
+++ b/systemd/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all install reload enable
+
+DESTDIR ?=
+UNITDIR ?= /etc/systemd/system
+
+all:
+	@echo "Targets: install reload enable"
+	@echo "reload implies install"
+	@echo "enable implies reload implies install"
+
+install:
+	install -D -m 0644 cpud.service $(DESTDIR)$(UNITDIR)/cpud.service
+
+reload: install
+	systemctl daemon-reload
+
+enable: reload
+	systemctl enable --now cpud.service

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,7 @@
+This is a primitive unit file for systemd.
+
+For now, it is for small embedded systems, with a shared key: /key.pub.
+
+We welcome improvements.
+
+

--- a/systemd/cpud.service
+++ b/systemd/cpud.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=CPU daemon
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/env cpud -pk /key.pub
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This is a dead simple systemd unit file, that assumes cpud is in root's $PATH, and a key in /key.pub.

It's really for basic use with small boards that have one user.